### PR TITLE
Add explicit relative favicon links so sub-path deployments show the icon

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 2026-07-03
+- Added explicit relative favicon links to the app and About pages. Browsers only auto-discover `/favicon.ico` at the domain root, so deployments served from a sub-path (e.g. GitHub Pages project sites) showed no favicon; the explicit `./favicon.ico` reference works at any mount point.
+
 ## 2026-06-23
 - Mobile-friendly UI pass (CSS only): the page now flows and scrolls vertically on phones (using `100dvh`) instead of being locked to the viewport, the toolbar wraps, primary controls have larger touch targets, the channel table is a bounded internal scroll area, the actions popup stays on-screen, and a new 560px breakpoint single-columns the serial actions and full-widths the view toggle. Desktop layout is unchanged.
 - Mobile channel table: instead of compressing all 17 columns to fit the screen (unreadable, overlapping headers), the table now keeps its natural width with no-wrap headers and readable, tappable cells, and scrolls horizontally. The Location column stays compact.

--- a/web/about.html
+++ b/web/about.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>About WebCHIRP</title>
+    <link rel="icon" href="./favicon.ico" sizes="any" />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body class="about-page">

--- a/web/index.html
+++ b/web/index.html
@@ -40,6 +40,7 @@
       name="twitter:image:alt"
       content="WebCHIRP interface showing radio controls, channel table, and debug output."
     />
+    <link rel="icon" href="./favicon.ico" sizes="any" />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>


### PR DESCRIPTION
web/favicon.ico existed but no page referenced it; browsers only auto-request /favicon.ico from the domain root, which works for the root-hosted deployment but 404s when the site is served from a sub-path (e.g. a GitHub Pages project site at /webchirp/). An explicit <link rel="icon" href="./favicon.ico"> on index.html and about.html resolves relative to the page, so the icon loads at any mount point. .ico is not a hashed dist asset, so the reference is stable in builds.
