### PR TITLE
Bound the pre-filled GitHub issue URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "screenshots": "node scripts/update-screenshots.mjs",
     "radio:read": "node --experimental-wasm-stack-switching scripts/radio-codeplug.mjs read",
     "radio:write": "node --experimental-wasm-stack-switching scripts/radio-codeplug.mjs write",
-    "test:channels": "node --test --experimental-wasm-stack-switching scripts/test-channel-list.mjs scripts/test-ui-radio-loading.mjs scripts/test-call-queue.mjs scripts/test-driver-import-race.mjs scripts/test-clipboard.mjs scripts/test-ui-channel-cut.mjs scripts/test-export-filename.mjs scripts/test-image-metadata.mjs scripts/test-datasources.mjs scripts/test-ui-repeater-query.mjs scripts/test-ui-file-drop.mjs scripts/test-dom-selectors.mjs scripts/test-gettext-builtins.mjs",
+    "test:channels": "node --test --experimental-wasm-stack-switching scripts/test-channel-list.mjs scripts/test-ui-radio-loading.mjs scripts/test-call-queue.mjs scripts/test-driver-import-race.mjs scripts/test-clipboard.mjs scripts/test-ui-channel-cut.mjs scripts/test-export-filename.mjs scripts/test-image-metadata.mjs scripts/test-datasources.mjs scripts/test-ui-repeater-query.mjs scripts/test-ui-file-drop.mjs scripts/test-dom-selectors.mjs scripts/test-gettext-builtins.mjs scripts/test-issue-report.mjs",
     "test:hw": "node --experimental-wasm-stack-switching scripts/test-hw-radio.mjs",
     "test:settings": "node --test --experimental-wasm-stack-switching scripts/test-radio-settings.mjs"
   },

--- a/scripts/test-issue-report.mjs
+++ b/scripts/test-issue-report.mjs
@@ -3,11 +3,13 @@ import test from "node:test";
 
 import { createIssueReporter } from "../web/js/ui/issue-report.js";
 
+// The debug excerpt is capped at a line count, with a URL-length backstop:
 // GitHub answers an over-long issue-prefill URL with HTTP 414 rather than the
-// form, and there is no POST prefill to fall back on, so the reporter has to
-// keep the generated URL inside its own budget no matter how big the debug
-// panel has grown. These tests pin that budget and the trimming order.
+// form, and there is no POST prefill to fall back on. These tests pin the line
+// cap, the backstop, and the fact that either kind of cut is disclosed in the
+// report rather than passing for a complete log.
 const URL_LIMIT = 6000;
+const TAIL_LINES = 40;
 
 function makeReporter({ debugLines = [], lastErrorSummary = "" } = {}) {
   const state = {
@@ -35,9 +37,24 @@ function actualBehaviorOf(url) {
   return params.get("actual_behavior");
 }
 
-test("a huge debug log still yields a URL within the budget", () => {
+test("a long session is cut to the last N lines and says so", () => {
   const debugLines = Array.from({ length: 400 }, (_, index) =>
     stampedLine(index, `SERIAL wrote 64 bytes in frame ${index} of the clone stream`),
+  );
+  const body = actualBehaviorOf(makeReporter({ debugLines }).buildIssueUrl());
+  const excerpt = body.split("```")[1].trim().split("\n");
+
+  assert.equal(excerpt.length, TAIL_LINES + 1, "N lines plus the trim note");
+  assert.match(excerpt[0], /earlier debug lines trimmed/);
+  assert.ok(excerpt.at(-1).includes("frame 399"), "newest line must survive");
+  assert.ok(!body.includes("frame 359 "), `only the last ${TAIL_LINES} lines ride along`);
+});
+
+test("one pathological line cannot push the URL past the backstop", () => {
+  // A single hex dump can outweigh the whole line budget, which is why the line
+  // cap alone is not enough to keep the URL inside GitHub's limit.
+  const debugLines = Array.from({ length: 10 }, (_, index) =>
+    stampedLine(index, `SERIAL read block ${index}: ${"A1B2C3D4 ".repeat(500)}`),
   );
   const url = makeReporter({ debugLines }).buildIssueUrl();
 
@@ -46,16 +63,6 @@ test("a huge debug log still yields a URL within the budget", () => {
     `expected URL within ${URL_LIMIT} chars, got ${url.length}`,
   );
   assert.match(actualBehaviorOf(url), /earlier debug lines trimmed/);
-});
-
-test("trimming keeps the newest lines and drops the oldest", () => {
-  const debugLines = Array.from({ length: 400 }, (_, index) =>
-    stampedLine(index, `SERIAL frame ${index} padding ${"x".repeat(60)}`),
-  );
-  const body = actualBehaviorOf(makeReporter({ debugLines }).buildIssueUrl());
-
-  assert.ok(body.includes("SERIAL frame 399 "), "newest line must survive");
-  assert.ok(!body.includes("SERIAL frame 0 "), "oldest line must be dropped");
 });
 
 test("a short log is reported in full, with no truncation note", () => {

--- a/scripts/test-issue-report.mjs
+++ b/scripts/test-issue-report.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createIssueReporter } from "../web/js/ui/issue-report.js";
+
+// GitHub answers an over-long issue-prefill URL with HTTP 414 rather than the
+// form, and there is no POST prefill to fall back on, so the reporter has to
+// keep the generated URL inside its own budget no matter how big the debug
+// panel has grown. These tests pin that budget and the trimming order.
+const URL_LIMIT = 6000;
+
+function makeReporter({ debugLines = [], lastErrorSummary = "" } = {}) {
+  const state = {
+    selectedRadio: { vendor: "Yaesu", model: "FT-60R" },
+    lastUsbVendorId: "0x10C4",
+    lastUsbProductId: "0xEA60",
+    runtimeInfo: { chirpRevision: "1a2b3c4d" },
+  };
+  const log = {
+    latestDebugTail: (lineCount) => debugLines.slice(-lineCount).join("\n"),
+    getLastErrorSummary: () => lastErrorSummary,
+    logDebug: () => {},
+  };
+  return createIssueReporter({ state, log });
+}
+
+function stampedLine(index, text) {
+  const seconds = String(index % 60).padStart(2, "0");
+  const minutes = String(Math.floor(index / 60) % 60).padStart(2, "0");
+  return `[2026-07-27T12:${minutes}:${seconds}.123Z] ${text}`;
+}
+
+function actualBehaviorOf(url) {
+  const params = new URL(url).searchParams;
+  return params.get("actual_behavior");
+}
+
+test("a huge debug log still yields a URL within the budget", () => {
+  const debugLines = Array.from({ length: 400 }, (_, index) =>
+    stampedLine(index, `SERIAL wrote 64 bytes in frame ${index} of the clone stream`),
+  );
+  const url = makeReporter({ debugLines }).buildIssueUrl();
+
+  assert.ok(
+    url.length <= URL_LIMIT,
+    `expected URL within ${URL_LIMIT} chars, got ${url.length}`,
+  );
+  assert.match(actualBehaviorOf(url), /earlier debug lines trimmed/);
+});
+
+test("trimming keeps the newest lines and drops the oldest", () => {
+  const debugLines = Array.from({ length: 400 }, (_, index) =>
+    stampedLine(index, `SERIAL frame ${index} padding ${"x".repeat(60)}`),
+  );
+  const body = actualBehaviorOf(makeReporter({ debugLines }).buildIssueUrl());
+
+  assert.ok(body.includes("SERIAL frame 399 "), "newest line must survive");
+  assert.ok(!body.includes("SERIAL frame 0 "), "oldest line must be dropped");
+});
+
+test("a short log is reported in full, with no truncation note", () => {
+  const debugLines = [
+    stampedLine(1, "STATUS Connected to radio."),
+    stampedLine(2, "DOWNLOAD ERROR Traceback: boom"),
+  ];
+  const body = actualBehaviorOf(
+    makeReporter({ debugLines, lastErrorSummary: "DOWNLOAD ERROR Traceback: boom" }).buildIssueUrl(),
+  );
+
+  assert.ok(!body.includes("trimmed"), "short logs must not be trimmed");
+  assert.ok(body.includes("STATUS Connected to radio."));
+  assert.ok(body.includes("DOWNLOAD ERROR Traceback: boom"));
+});
+
+test("log stamps are compacted to the time of day", () => {
+  const debugLines = [stampedLine(5, "STATUS Ready.")];
+  const body = actualBehaviorOf(makeReporter({ debugLines }).buildIssueUrl());
+
+  assert.ok(body.includes("[12:00:05] STATUS Ready."), body);
+  assert.ok(!body.includes("2026-07-27"), "the date adds no signal to a report");
+});
+
+test("an empty debug panel says so instead of emitting an empty block", () => {
+  const body = actualBehaviorOf(makeReporter().buildIssueUrl());
+
+  assert.ok(body.includes("<no debug logs captured>"));
+});

--- a/web/js/ui/issue-report.js
+++ b/web/js/ui/issue-report.js
@@ -2,14 +2,16 @@ import { detectBrowserVersion, detectOperatingSystem } from "./format.js";
 
 const ISSUE_TEMPLATE_NAME = "radio_bug_report.yml";
 const ISSUE_NEW_URL = "https://github.com/jasiek/webchirp/issues/new";
-// GitHub answers over-long prefill URLs with HTTP 414 instead of the form, and
-// a long debug session can produce a query string many times that size. There
-// is no POST prefill to fall back on — the issue form only reads query params —
-// so the whole URL is budgeted and the debug excerpt is trimmed to fit.
+// How much of the debug panel rides along. This is the knob that decides the
+// URL length in practice: 40 lines holds a full CHIRP traceback plus the serial
+// traffic leading up to it, for roughly a 3k-character URL.
+const DEBUG_TAIL_LINES = 40;
+// Backstop only. GitHub answers over-long prefill URLs with HTTP 414 instead of
+// the form, and there is no POST prefill to fall back on — the issue form only
+// reads query params. Normal lines never reach this; one pathological line (a
+// hex dump, a single-line traceback) would, so the built URL is measured and
+// trimmed rather than trusted to the line count alone.
 const ISSUE_URL_LIMIT = 6000;
-// Ask the panel for more lines than will usually fit: the URL budget above is
-// the real governor, so short lines buy more context instead of wasting room.
-const DEBUG_TAIL_LINES = 120;
 const NO_DEBUG_PLACEHOLDER = "<no debug logs captured>";
 const TRUNCATION_NOTE =
   "<earlier debug lines trimmed - use Copy in Debug Output for the full log>";
@@ -30,11 +32,12 @@ function compactDebugLines(tail) {
 // the built URL still fits. `measure` builds the real URL rather than estimating
 // the encoded size, because the estimate and URLSearchParams disagree on every
 // space, and a debug tail is mostly spaces.
-function fitDebugExcerpt(lines, measure, limit) {
+function fitDebugExcerpt(lines, { measure, limit, alreadyTrimmed }) {
   if (!lines.length) {
     return NO_DEBUG_PLACEHOLDER;
   }
-  const whole = lines.join("\n");
+  const head = alreadyTrimmed ? [TRUNCATION_NOTE] : [];
+  const whole = [...head, ...lines].join("\n");
   if (measure(whole) <= limit) {
     return whole;
   }
@@ -96,14 +99,20 @@ export function createIssueReporter({ state, log }) {
       return `${ISSUE_NEW_URL}?${params.toString()}`;
     };
 
+    // Ask for one line more than is kept: getting it back is how we learn the
+    // panel held more than the excerpt shows, so the report can say the log was
+    // cut rather than looking like the session started at the first line here.
+    const available = compactDebugLines(log.latestDebugTail(DEBUG_TAIL_LINES + 1));
+    const cutByLineCount = available.length > DEBUG_TAIL_LINES;
+
     // The fixed fields alone can overrun the limit on a pathological error
     // summary, in which case no debug line fits and only the truncation note
     // survives — the report is still worth filing without the excerpt.
-    const excerpt = fitDebugExcerpt(
-      compactDebugLines(log.latestDebugTail(DEBUG_TAIL_LINES)),
-      (debugExcerpt) => buildUrl(debugExcerpt).length,
-      ISSUE_URL_LIMIT,
-    );
+    const excerpt = fitDebugExcerpt(available.slice(cutByLineCount ? 1 : 0), {
+      measure: (debugExcerpt) => buildUrl(debugExcerpt).length,
+      limit: ISSUE_URL_LIMIT,
+      alreadyTrimmed: cutByLineCount,
+    });
     return buildUrl(excerpt);
   }
 

--- a/web/js/ui/issue-report.js
+++ b/web/js/ui/issue-report.js
@@ -2,6 +2,53 @@ import { detectBrowserVersion, detectOperatingSystem } from "./format.js";
 
 const ISSUE_TEMPLATE_NAME = "radio_bug_report.yml";
 const ISSUE_NEW_URL = "https://github.com/jasiek/webchirp/issues/new";
+// GitHub answers over-long prefill URLs with HTTP 414 instead of the form, and
+// a long debug session can produce a query string many times that size. There
+// is no POST prefill to fall back on — the issue form only reads query params —
+// so the whole URL is budgeted and the debug excerpt is trimmed to fit.
+const ISSUE_URL_LIMIT = 6000;
+// Ask the panel for more lines than will usually fit: the URL budget above is
+// the real governor, so short lines buy more context instead of wasting room.
+const DEBUG_TAIL_LINES = 120;
+const NO_DEBUG_PLACEHOLDER = "<no debug logs captured>";
+const TRUNCATION_NOTE =
+  "<earlier debug lines trimmed - use Copy in Debug Output for the full log>";
+
+// Drop the date and sub-second precision from log stamps: within one report the
+// date never varies and the wall clock only matters for ordering, so this buys
+// ~30 encoded characters a line of excerpt budget for free.
+function compactDebugLines(tail) {
+  return String(tail || "")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) =>
+      line.replace(/^\[\d{4}-\d{2}-\d{2}T(\d{2}:\d{2}:\d{2})[.\d]*Z?\]\s*/, "[$1] "),
+    );
+}
+
+// Keep the newest lines — the failure is at the tail — and add older ones while
+// the built URL still fits. `measure` builds the real URL rather than estimating
+// the encoded size, because the estimate and URLSearchParams disagree on every
+// space, and a debug tail is mostly spaces.
+function fitDebugExcerpt(lines, measure, limit) {
+  if (!lines.length) {
+    return NO_DEBUG_PLACEHOLDER;
+  }
+  const whole = lines.join("\n");
+  if (measure(whole) <= limit) {
+    return whole;
+  }
+
+  let kept = [];
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const candidate = [TRUNCATION_NOTE, lines[index], ...kept];
+    if (measure(candidate.join("\n")) > limit) {
+      break;
+    }
+    kept = candidate.slice(1);
+  }
+  return [TRUNCATION_NOTE, ...kept].join("\n");
+}
 
 // Pre-fills the GitHub bug-report template with the selected radio, the USB ids
 // seen on the last connect, the browser/OS, the CHIRP revision, and a tail of
@@ -16,37 +63,48 @@ export function createIssueReporter({ state, log }) {
     const lastErrorSummary = log.getLastErrorSummary();
     const bugSummary = lastErrorSummary || "manual report";
     const issueTitle = `Bug report: ${radioMake} ${radioModel} - ${bugSummary}`;
-    const debugTail = log.latestDebugTail(120);
     const steps = [
       "1. Open WebCHIRP",
       "2. Select a radio make/model if relevant",
       "3. Perform the action that shows the bug",
       "4. Describe what happened",
     ].join("\n");
-    const actualBehavior = [
-      lastErrorSummary || "Manual report with no captured runtime error yet.",
-      "",
-      "Debug output excerpt:",
-      "```",
-      debugTail || "<no debug logs captured>",
-      "```",
-    ].join("\n");
 
-    const params = new URLSearchParams({
-      template: ISSUE_TEMPLATE_NAME,
-      title: issueTitle.slice(0, 240),
-      radio_make: radioMake,
-      radio_model: radioModel,
-      usb_vendor_id: state.lastUsbVendorId || "Unknown / not connected",
-      usb_product_id: state.lastUsbProductId || "Unknown / not connected",
-      operating_system: detectOperatingSystem(),
-      browser_and_version: detectBrowserVersion(),
-      chirp_revision: state.runtimeInfo.chirpRevision || "unknown",
-      steps_to_reproduce: steps,
-      expected_behavior: "The reported action should work without the observed bug.",
-      actual_behavior: actualBehavior,
-    });
-    return `${ISSUE_NEW_URL}?${params.toString()}`;
+    const buildUrl = (debugExcerpt) => {
+      const actualBehavior = [
+        lastErrorSummary || "Manual report with no captured runtime error yet.",
+        "",
+        "Debug output excerpt:",
+        "```",
+        debugExcerpt,
+        "```",
+      ].join("\n");
+      const params = new URLSearchParams({
+        template: ISSUE_TEMPLATE_NAME,
+        title: issueTitle.slice(0, 240),
+        radio_make: radioMake,
+        radio_model: radioModel,
+        usb_vendor_id: state.lastUsbVendorId || "Unknown / not connected",
+        usb_product_id: state.lastUsbProductId || "Unknown / not connected",
+        operating_system: detectOperatingSystem(),
+        browser_and_version: detectBrowserVersion(),
+        chirp_revision: state.runtimeInfo.chirpRevision || "unknown",
+        steps_to_reproduce: steps,
+        expected_behavior: "The reported action should work without the observed bug.",
+        actual_behavior: actualBehavior,
+      });
+      return `${ISSUE_NEW_URL}?${params.toString()}`;
+    };
+
+    // The fixed fields alone can overrun the limit on a pathological error
+    // summary, in which case no debug line fits and only the truncation note
+    // survives — the report is still worth filing without the excerpt.
+    const excerpt = fitDebugExcerpt(
+      compactDebugLines(log.latestDebugTail(DEBUG_TAIL_LINES)),
+      (debugExcerpt) => buildUrl(debugExcerpt).length,
+      ISSUE_URL_LIMIT,
+    );
+    return buildUrl(excerpt);
   }
 
   function openPrefilledIssue() {


### PR DESCRIPTION
## What changed

The **Report Bug** button builds a GitHub issue-prefill URL carrying a tail of the Debug Output panel. Nothing bounded it: after a long session the query string alone encoded to ~13.7k characters, and GitHub answers an over-long prefill URL with **HTTP 414** instead of the issue form.

- The debug excerpt is now capped at the last **40 lines** — enough for a full CHIRP traceback plus the serial traffic leading up to it, for a ~3.2k-character URL.
- A **6000-character URL cap** backs that up. The line cap alone doesn't bound the URL: one pathological line (a hex dump, a single-line traceback) can outweigh 40 normal ones. Lines are kept newest-first — the failure is at the tail — while the *actually built* URL still fits.
- Either kind of cut is disclosed in the report. The excerpt is requested one line deeper than it is kept; getting that extra line back is how the reporter knows to emit a trim note pointing at the **Copy** button in Debug Output, rather than letting a 40-line excerpt pass for a complete session log.
- Log stamps are compacted from a full ISO timestamp to the time of day (`[2026-07-27T12:00:05.123Z]` → `[12:00:05]`), which fits roughly a third more lines in the same space. The date never varies within one report.

## On POSTing instead

Not available. GitHub's issue form only reads prefill values from query parameters — there's no POST-prefill endpoint, and a cross-site POST to `/issues/new` would be rejected by their CSRF protection. The authenticated `POST /repos/:owner/:repo/issues` API would need a token in the browser, which a static app shouldn't carry. Shortening is the only route.

## Sizing

Measured on a realistic tail (serial traffic plus a 7-line CHIRP traceback); fixed template fields cost ~780 characters, each line ~61:

| lines kept | URL length |
| --- | --- |
| 20 | 1996 |
| 30 | 2606 |
| **40 (this PR)** | **3216** |
| 120 (previous) | 5947 |

## Reviewer notes

- 40 is a judgment call, not a constraint. `DEBUG_TAIL_LINES` in `web/js/ui/issue-report.js` is a one-line change if a traceback plus context usually needs more room; `TAIL_LINES` in the test file tracks it.
- 6000 is conservative — GitHub tolerates closer to 8k. Raising it only matters for the pathological-line case, since the line cap governs everything else.
- The measured-not-estimated fit is deliberate: `encodeURIComponent` and `URLSearchParams` disagree on every space, and a debug tail is mostly spaces, so estimating left ~20% of the budget unspent.

## Testing

New `scripts/test-issue-report.mjs` (5 tests) covers the line cap and its notice, the URL backstop under a pathological line, short logs passing through untouched, stamp compaction, and the empty-panel placeholder. Wired into `npm run test:channels` — 83 tests pass.

## Dependencies

None added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)