### PR TITLE
Align endpoint handling across the WebUSB serial drivers

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -72,6 +72,7 @@ CHIRP `b7ae1b6`.
 
 ## WebUSB serial adapters
 
+- **webusb-test-endpoints-must-name-their-type** (2026-08-17): WebUSB's `USBEndpoint` descriptors always identify their transfer `type`, but the original FTDI unit-test fake omitted it because that driver selected endpoints by direction alone. Once FTDI correctly filters for `type === "bulk"`, an untyped fake rejects every otherwise-valid `open()`. Driver fixtures must model descriptor type explicitly; the FTDI regression test also places an interrupt IN endpoint after bulk IN so the old direction-only selection demonstrably chooses the wrong pipe.
 - **ch340-version-not-bcddevice** (2026-07-28): the CH340/CH341 protocol branches on the chip version returned by vendor request `0x5F`, **not** on the USB `bcdDevice` word — an 0x1a86:0x7523 cable reporting `bcdDevice 0xc233` still reports a version of 0x30/0x31 over the wire. Version > 0x27 sets bit 7 of the prescaler value (otherwise the chip withholds data until a full 32-byte packet, which stalls short CHIRP replies); version >= 0x30 configures framing through the LCR register pair, and older parts are left at their 8N1 defaults.
 - **webusb-vendor-filters-are-too-broad-for-wch** (2026-07-28): FTDI and Prolific can be filtered by vendor id alone, but WCH's 0x1a86 also covers CH9102/CH343 parts that enumerate as CDC-ACM (and non-serial chips). The CH340 chooser filters on exact vendor/product pairs so those devices fall through to the CDC polyfill instead of getting the CH340 register map.
 

--- a/scripts/test-ftdi-webusb.mjs
+++ b/scripts/test-ftdi-webusb.mjs
@@ -6,7 +6,14 @@ import { FtdiSerialPort } from "../web/js/ftdi-webusb.js";
 // answers them, the way real hardware leaves a transfer outstanding until bytes
 // arrive. A driver that keeps a queue is only observable against a fake that
 // models the queue, so this cannot be a list of pre-baked results.
-function makeFakeDevice({ cancelOnClearHalt = false } = {}) {
+function makeFakeDevice({
+  cancelOnClearHalt = false,
+  endpoints = [
+    { type: "bulk", direction: "in", endpointNumber: 1, packetSize: 64 },
+    { type: "bulk", direction: "out", endpointNumber: 2, packetSize: 64 },
+  ],
+  interfaceNumber = 0,
+} = {}) {
   const controlCalls = [];
   const clearHaltCalls = [];
   const transferInCalls = [];
@@ -19,13 +26,8 @@ function makeFakeDevice({ cancelOnClearHalt = false } = {}) {
     configuration: {
       interfaces: [
         {
-          interfaceNumber: 0,
-          alternate: {
-            endpoints: [
-              { direction: "in", endpointNumber: 1, packetSize: 64 },
-              { direction: "out", endpointNumber: 2, packetSize: 64 },
-            ],
-          },
+          interfaceNumber,
+          alternate: { endpoints },
         },
       ],
     },
@@ -102,6 +104,40 @@ test("FtdiSerialPort.open() purges FIFOs and sets the latency timer", async () =
   assert.ok(port.readable, "readable stream must be set up");
   assert.ok(port.writable, "writable stream must be set up");
 });
+
+test("FtdiSerialPort.open() ignores interrupt endpoints when selecting bulk data", async () => {
+  const { device } = makeFakeDevice({
+    endpoints: [
+      { type: "bulk", direction: "in", endpointNumber: 1, packetSize: 64 },
+      { type: "bulk", direction: "out", endpointNumber: 2, packetSize: 64 },
+      // Keep this last: the old direction-only loop overwrote bulk IN with it.
+      { type: "interrupt", direction: "in", endpointNumber: 3, packetSize: 8 },
+    ],
+  });
+  const port = new FtdiSerialPort(device);
+
+  await port.open({ baudRate: 9600 });
+
+  assert.equal(port._inEndpoint, 1);
+  assert.equal(port._outEndpoint, 2);
+  assert.equal(port.packetSize, 64);
+});
+
+for (const [missingDirection, endpoints] of [
+  ["IN", [{ type: "bulk", direction: "out", endpointNumber: 2, packetSize: 64 }]],
+  ["OUT", [{ type: "bulk", direction: "in", endpointNumber: 1, packetSize: 64 }]],
+]) {
+  test(`FtdiSerialPort.open() rejects a missing bulk ${missingDirection} endpoint`, async () => {
+    const { device, controlCalls } = makeFakeDevice({ endpoints, interfaceNumber: 7 });
+    const port = new FtdiSerialPort(device);
+
+    await assert.rejects(
+      port.open({ baudRate: 9600 }),
+      /FTDI: bulk IN\/OUT endpoints not found on interface 7/,
+    );
+    assert.deepEqual(controlCalls, [], "endpoint validation must happen before FTDI initialization");
+  });
+}
 
 test("FtdiSerialPort read path survives status-only packets (the Android wedge)", async () => {
   // Regression for a read-path deadlock observed on Android (exactly two

--- a/scripts/test-pl2303-webusb.mjs
+++ b/scripts/test-pl2303-webusb.mjs
@@ -32,7 +32,17 @@ function descriptorBytes({ usbVersion, deviceClass, maxPacketSize0, deviceVersio
 
 // Fake USBDevice for a PL2303: interrupt IN + bulk OUT + bulk IN endpoints,
 // records all control transfers, answers GET_DESCRIPTOR and the HX probe.
-function makeFakeDevice({ descriptor, hxProbeSucceeds = true, cancelOnClearHalt = false }) {
+function makeFakeDevice({
+  descriptor,
+  hxProbeSucceeds = true,
+  cancelOnClearHalt = false,
+  endpoints = [
+    { type: "interrupt", direction: "in", endpointNumber: 1, packetSize: 10 },
+    { type: "bulk", direction: "out", endpointNumber: 2, packetSize: 64 },
+    { type: "bulk", direction: "in", endpointNumber: 3, packetSize: 64 },
+  ],
+  interfaceNumber = 0,
+}) {
   const controlIn = [];
   const controlOut = [];
   const transferInCalls = [];
@@ -45,14 +55,8 @@ function makeFakeDevice({ descriptor, hxProbeSucceeds = true, cancelOnClearHalt 
     configuration: {
       interfaces: [
         {
-          interfaceNumber: 0,
-          alternate: {
-            endpoints: [
-              { type: "interrupt", direction: "in", endpointNumber: 1, packetSize: 10 },
-              { type: "bulk", direction: "out", endpointNumber: 2, packetSize: 64 },
-              { type: "bulk", direction: "in", endpointNumber: 3, packetSize: 64 },
-            ],
-          },
+          interfaceNumber,
+          alternate: { endpoints },
         },
       ],
     },
@@ -168,6 +172,25 @@ test("HX open() runs the legacy startup with kernel-correct request types", asyn
   // Bulk endpoints selected, interrupt endpoint skipped.
   assert.equal(port._inEndpoint, 3);
   assert.equal(port._outEndpoint, 2);
+});
+
+test("Pl2303SerialPort.open() reports the actual interface when a bulk endpoint is missing", async () => {
+  const { device, controlIn, controlOut } = makeFakeDevice({
+    descriptor: HX_DESCRIPTOR,
+    endpoints: [
+      { type: "interrupt", direction: "in", endpointNumber: 1, packetSize: 10 },
+      { type: "bulk", direction: "out", endpointNumber: 2, packetSize: 64 },
+    ],
+    interfaceNumber: 7,
+  });
+  const port = new Pl2303SerialPort(device);
+
+  await assert.rejects(
+    port.open({ baudRate: 9600 }),
+    /PL2303: bulk IN\/OUT endpoints not found on interface 7/,
+  );
+  assert.deepEqual(controlIn, [], "endpoint validation must happen before PL2303 probing");
+  assert.deepEqual(controlOut, [], "endpoint validation must happen before PL2303 initialization");
 });
 
 test("HXN open() skips the legacy startup and uses HXN registers", async () => {

--- a/web/js/ftdi-webusb.js
+++ b/web/js/ftdi-webusb.js
@@ -164,13 +164,24 @@ export class FtdiSerialPort {
       );
     }
 
+    // Current FTDI parts expose a bare bulk pair here, but filter on type
+    // anyway so a variant that adds an interrupt endpoint (as PL2303 and CH340
+    // do for modem status) cannot silently bind the wrong endpoint.
     for (const endpoint of iface.alternate.endpoints) {
+      if (endpoint.type !== "bulk") {
+        continue;
+      }
       if (endpoint.direction === "in") {
         this._inEndpoint = endpoint.endpointNumber;
         this._inPacketSize = endpoint.packetSize || this._inPacketSize;
       } else if (endpoint.direction === "out") {
         this._outEndpoint = endpoint.endpointNumber;
       }
+    }
+    if (!this._inEndpoint || !this._outEndpoint) {
+      throw new Error(
+        `FTDI: bulk IN/OUT endpoints not found on interface ${this._interfaceNumber}`,
+      );
     }
 
     await this._controlOut(SIO_RESET, 0x0000, PORT_INDEX);

--- a/web/js/pl2303-webusb.js
+++ b/web/js/pl2303-webusb.js
@@ -312,7 +312,9 @@ export class Pl2303SerialPort {
       }
     }
     if (!this._inEndpoint || !this._outEndpoint) {
-      throw new Error("PL2303: bulk IN/OUT endpoints not found on interface 0");
+      throw new Error(
+        `PL2303: bulk IN/OUT endpoints not found on interface ${this._interfaceNumber}`,
+      );
     }
 
     const descriptor = await this._readDeviceDescriptor();


### PR DESCRIPTION
Closes #25.

The three WebUSB serial drivers selected and validated their bulk endpoints differently. This aligns the FTDI and PL2303 paths with CH340 so the pattern is safe to reuse for future chip drivers.

## Changes

### FTDI (`web/js/ftdi-webusb.js`)

- Select only endpoints whose USB transfer type is `bulk`, so a later interrupt IN endpoint cannot replace the serial-data endpoint.
- Fail immediately when either bulk IN or bulk OUT is missing, before FTDI control initialization begins.
- Report the actual claimed interface number in the failure.

### PL2303 (`web/js/pl2303-webusb.js`)

- Report `this._interfaceNumber` when the bulk endpoint pair is missing instead of hard-coding interface 0.

### Tests

- Model endpoint transfer types in the FTDI fixture.
- Prove FTDI ignores an interrupt IN endpoint listed after bulk IN.
- Cover missing FTDI bulk IN and bulk OUT independently and verify validation precedes initialization.
- Cover the PL2303 diagnostic with a nonzero interface number.

## Impact

Existing verified adapters expose the expected bulk pair, so this is defensive hardening rather than a fix for a reproduced hardware failure. It prevents unusual endpoint layouts from silently selecting the wrong pipe and turns malformed layouts into an immediate, actionable diagnostic.

Rebased onto current `master` on 2026-08-17. No new dependencies.

## Validation

- `npm test` — syntax, 209 channel/UI/runtime tests, WebUSB, radio settings, and build tests passed
- `npm run test:webusb` — 54 passing, 0 failing
