### PR TITLE
Prune low-value analytics dimensions, merge make/model into radio

### DIFF
--- a/scripts/test-analytics-events.mjs
+++ b/scripts/test-analytics-events.mjs
@@ -78,8 +78,7 @@ test("radioEventParams sends driver identity and nothing else", () => {
       baudRate: 9600,
     }),
     {
-      radio_make: "Baofeng",
-      radio_model: "UV-5R",
+      radio: "Baofeng UV-5R",
       radio_module: "chirp.drivers.uv5r",
       radio_class: "BaofengUV5R",
     },

--- a/scripts/test-analytics.mjs
+++ b/scripts/test-analytics.mjs
@@ -159,12 +159,12 @@ test("init is inert without a window and keeps an existing gtag", () => {
 test("trackEvent forwards params and reports when analytics is absent", () => {
   const win = makeWindow({ displayModes: ["standalone"] });
   initAnalytics(win);
-  assert.equal(trackEvent("radio_download", { radio_make: "Baofeng" }, win), true);
+  assert.equal(trackEvent("radio_download", { radio: "Baofeng UV-5R" }, win), true);
   // Every event carries the launch context, since config parameters cannot be
   // relied on to reach events the way a bare set() cannot.
   assert.deepEqual(eventsNamed(win, "radio_download")[0][2], {
     display_mode: "standalone",
-    radio_make: "Baofeng",
+    radio: "Baofeng UV-5R",
   });
 
   // An explicit value still wins over the automatic one.

--- a/web/js/analytics.js
+++ b/web/js/analytics.js
@@ -51,15 +51,9 @@ export const CUSTOM_DIMENSIONS = Object.freeze([
     scope: "EVENT",
   },
   {
-    parameterName: "radio_make",
-    displayName: "Radio make",
-    description: "Vendor of the radio a clone operation ran against.",
-    scope: "EVENT",
-  },
-  {
-    parameterName: "radio_model",
-    displayName: "Radio model",
-    description: "Model of the radio a clone operation ran against.",
+    parameterName: "radio",
+    displayName: "Radio",
+    description: "Make and model of the radio an operation ran against, e.g. Baofeng UV-5R.",
     scope: "EVENT",
   },
   {
@@ -72,12 +66,6 @@ export const CUSTOM_DIMENSIONS = Object.freeze([
     parameterName: "radio_class",
     displayName: "Radio driver class",
     description: "CHIRP driver class backing the selected radio.",
-    scope: "EVENT",
-  },
-  {
-    parameterName: "radio_support",
-    displayName: "Radio support",
-    description: "Whether the selected radio is a clone-mode radio or a live-mode one this UI cannot program.",
     scope: "EVENT",
   },
   {
@@ -117,27 +105,9 @@ export const CUSTOM_DIMENSIONS = Object.freeze([
     scope: "EVENT",
   },
   {
-    parameterName: "radio_count",
-    displayName: "Radio count",
-    description: "Number of radios the catalog offered once the app was ready.",
-    scope: "EVENT",
-  },
-  {
-    parameterName: "serial_capability",
-    displayName: "Serial capability",
-    description: "What the browser can reach a radio with: Web Serial, WebUSB, both, or neither.",
-    scope: "EVENT",
-  },
-  {
     parameterName: "transport",
     displayName: "Serial transport",
     description: "Transport a serial connection actually opened over.",
-    scope: "EVENT",
-  },
-  {
-    parameterName: "requested_transport",
-    displayName: "Requested transport",
-    description: "Transport the user asked for, which the one that won can differ from.",
     scope: "EVENT",
   },
   {
@@ -201,24 +171,6 @@ export const CUSTOM_DIMENSIONS = Object.freeze([
     scope: "EVENT",
   },
   {
-    parameterName: "band_count",
-    displayName: "Band filter count",
-    description: "How many bands a repeater query was filtered to.",
-    scope: "EVENT",
-  },
-  {
-    parameterName: "mode_count",
-    displayName: "Mode filter count",
-    description: "How many modes a repeater query was filtered to.",
-    scope: "EVENT",
-  },
-  {
-    parameterName: "only_working",
-    displayName: "Working repeaters only",
-    description: "Whether a repeater query excluded repeaters that are not reported as working.",
-    scope: "EVENT",
-  },
-  {
     parameterName: "located",
     displayName: "Query located",
     description: "Whether a repeater query carried a position rather than searching blind.",
@@ -228,12 +180,6 @@ export const CUSTOM_DIMENSIONS = Object.freeze([
     parameterName: "preset",
     displayName: "Preset",
     description: "Which band-plan preset a block of channels was inserted from.",
-    scope: "EVENT",
-  },
-  {
-    parameterName: "column",
-    displayName: "Channel column",
-    description: "CHIRP channel column that was edited, reported once per column per session.",
     scope: "EVENT",
   },
   {

--- a/web/js/ui.js
+++ b/web/js/ui.js
@@ -196,14 +196,11 @@ export function createUiController() {
         // "sources" means the prebuilt catalog was missing or stale and every
         // driver had to be imported in Pyodide first — a much slower start.
         catalog_source: catalogResponse.source || "unknown",
-        radio_count: state.radioCatalog.length,
-        serial_capability: serial.capabilityLabel(),
       });
     } catch (error) {
       catalog.setRadioSelectPlaceholder("Unavailable");
       trackEvent("app_init_failed", {
         duration_ms: Date.now() - startedAt,
-        serial_capability: serial.capabilityLabel(),
         error_kind: classifyErrorKind(error),
         error_type: errorTypeName(error),
       });

--- a/web/js/ui/analytics.js
+++ b/web/js/ui/analytics.js
@@ -21,17 +21,16 @@ import { errorDetails } from "./format.js";
 
 export { trackEvent } from "../analytics.js";
 
-// The driver identity every radio-scoped event carries. Vendor/model answer
-// "which radios do people own", module/class answer "which CHIRP driver ran",
-// and the two differ often enough (one driver serves many models) to be worth
-// sending both.
+// The driver identity every radio-scoped event carries. radio answers "which
+// radios do people own", module/class answer "which CHIRP driver ran", and the
+// two differ often enough (one driver serves many models) to be worth sending
+// both.
 export function radioEventParams(radio) {
   if (!radio) {
     return {};
   }
   return {
-    radio_make: String(radio.vendor || ""),
-    radio_model: String(radio.model || ""),
+    radio: [radio.vendor, radio.model].filter(Boolean).map(String).join(" "),
     radio_module: String(radio.module || ""),
     radio_class: String(radio.className || ""),
   };

--- a/web/js/ui/channel-table.js
+++ b/web/js/ui/channel-table.js
@@ -22,10 +22,6 @@ export function createChannelTable({ dom, state, log, actions }) {
   let selectedRowIndexes = new Set();
   let selectionAnchorIndex = null;
   const invalidCellKeys = new Set();
-  // Columns already reported this session. Editing is per-keystroke, and the
-  // question is which fields people use at all, so each column reports once
-  // rather than once per edit.
-  const trackedEditColumns = new Set();
 
   // --- Grid rendering -----------------------------------------------------
   // This grid is the heaviest DOM in the app: every enum cell carries a full
@@ -931,15 +927,6 @@ export function createChannelTable({ dom, state, log, actions }) {
     const row = state.currentRows[rowIdx];
     const meta = state.radioMetadata.columns?.[column] || {};
     const next = normalizeValue(column, editor.value, meta, row[column]);
-    // Reported before the write, so focusout on a cell nobody touched does not
-    // count as an edit. Only the column name travels — never the value.
-    if (next !== row[column] && !trackedEditColumns.has(column)) {
-      trackedEditColumns.add(column);
-      trackEvent("channel_edit", {
-        ...radioEventParams(state.selectedRadio),
-        column,
-      });
-    }
     row[column] = next;
     editor.value = next;
   }

--- a/web/js/ui/radio-catalog.js
+++ b/web/js/ui/radio-catalog.js
@@ -82,8 +82,7 @@ export function createRadioCatalog(ctx) {
   // Report which radio a user landed on and how they got there. Deliberately
   // not fired from refreshModelOptions(), which also runs at boot and when a
   // vendor change defaults the model: only the paths below are a user choosing
-  // a radio. The live-mode flag rides along because picking one of those is a
-  // dead end in this UI, and the size of that group is worth knowing.
+  // a radio.
   function trackRadioSelected(radio, method) {
     if (!radio) {
       return;
@@ -91,7 +90,6 @@ export function createRadioCatalog(ctx) {
     trackEvent("radio_selected", {
       ...radioEventParams(radio),
       method,
-      radio_support: radio.isLiveRadio ? "live_unsupported" : "clone",
     });
   }
 

--- a/web/js/ui/repeater-query.js
+++ b/web/js/ui/repeater-query.js
@@ -253,9 +253,6 @@ export function createRepeaterQuery(ctx) {
     trackEvent("repeater_import", {
       repeater_source: source.key,
       country: String(dom.przemiennikiCountryEl.value || "").toLowerCase() || "any",
-      band_count: selectedBands().length,
-      mode_count: selectedModes().length,
-      only_working: dom.przemiennikiOnlyWorkingEl.checked ? "yes" : "no",
       located: dom.przemiennikiLatitudeEl.value ? "yes" : "no",
       result_count: parsed.repeaters.length,
     });

--- a/web/js/ui/rsgb-query.js
+++ b/web/js/ui/rsgb-query.js
@@ -221,13 +221,9 @@ export function createRsgbQuery(ctx) {
     ctx.table.insertRowsAtSelectionOrEnd(rows, "RSGB ETCC");
     // result_count is the point of this event: a query that returns nothing
     // means the filters, the radius or the API are wrong, and that is invisible
-    // otherwise. The band and mode filters are reported only as counts, and the
-    // position never at all.
+    // otherwise. The band and mode filters and the position are never reported.
     trackEvent("repeater_import", {
       repeater_source: REPEATER_SOURCE,
-      band_count: checkedValues(dom.rsgbBandListEl, "rsgb-band").length,
-      mode_count: modes.length,
-      only_working: dom.rsgbOnlyOperationalEl.checked ? "yes" : "no",
       located: "yes",
       result_count: rows.length,
     });

--- a/web/js/ui/serial-actions.js
+++ b/web/js/ui/serial-actions.js
@@ -33,22 +33,6 @@ export function createSerialActions(ctx) {
     updateSerialActionState();
   }
 
-  // The browser's serial story as one reportable value. Sent with app_ready so
-  // the share of visitors whose browser can never reach a radio is measured
-  // against the same denominator as everyone who got that far.
-  function capabilityLabel() {
-    if (capability.native && capability.webusb) {
-      return "native+webusb";
-    }
-    if (capability.native) {
-      return "native";
-    }
-    if (capability.webusb) {
-      return "webusb";
-    }
-    return "none";
-  }
-
   function setSerialButtonsBusy(busy) {
     dom.serialConnectToggleEl.disabled = busy;
     dom.webusbConnectToggleEl.disabled = busy;
@@ -86,14 +70,12 @@ export function createSerialActions(ctx) {
       trackEvent("serial_connected", {
         ...radioEventParams(state.selectedRadio),
         transport: transport || "unknown",
-        requested_transport: preferredTransport,
       });
     } catch (error) {
       // A user who closes the browser's port picker lands here too; error_kind
       // separates that from an adapter the browser could not open.
       trackEvent("serial_connect_failed", {
         ...radioEventParams(state.selectedRadio),
-        requested_transport: preferredTransport,
         error_kind: classifyErrorKind(error),
         error_type: errorTypeName(error),
       });
@@ -445,7 +427,6 @@ export function createSerialActions(ctx) {
 
   return {
     bindEvents,
-    capabilityLabel,
     setSerialController,
     setSidebarControlsEnabled,
     setSerialSupportWarningVisible,


### PR DESCRIPTION
## Summary
- Removes eight low-value custom dimensions from `CUSTOM_DIMENSIONS` and every event that sent them: `radio_support`, `radio_count`, `serial_capability`, `requested_transport`, `band_count`, `mode_count`, `only_working`, `column` (affected events: `app_ready`, `app_init_failed`, `radio_selected`, `serial_connected`, `serial_connect_failed`, both `repeater_import` sites).
- Consolidates `radio_make`/`radio_model` into a single `radio` dimension (e.g. "Baofeng UV-5R") built in `radioEventParams()`; `radio_module`/`radio_class` are unchanged.
- Deletes the `channel_edit` event outright — reporting the edited column was its only purpose — along with its per-session dedup set.
- Deletes `capabilityLabel()` in serial-actions; the `serial_capability` parameter was its last caller.
- The `radio_make`/`radio_model` in `issue-report.js` are GitHub issue-form field names, not analytics, and are untouched.

## Deployment note
After merging, run `npm run ga:dimensions -- --apply --archive-extra` to create the `radio` dimension and archive the retired ones on the GA property. `radio` starts with empty history; old data stays queryable under the archived dimensions.

## Dependencies
No new dependencies.

## Testing
- `npm test`: all 859 tests pass, including the scanner in `scripts/test-ga-dimensions.mjs` that verifies every sent parameter is declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)