### PR TITLE
Explain the iOS platform gap in the unsupported-browser modal

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -401,8 +401,10 @@
       setBrowserUnsupportedOverlayVisible: no serial transport (radio
       programming impossible, file editing fine) and no WASM stack switching
       (drivers cannot load at all — old Firefox). Safari lacks both, so both
-      blocks show there at once. "Continue anyway" dismisses the overlay so
-      whatever still works stays reachable.
+      blocks show there at once. On iOS/iPadOS a third block replaces both:
+      every browser there is WebKit, so switching browsers cannot help and the
+      other two blocks would give advice that does not apply. "Continue anyway"
+      dismisses the overlay so whatever still works stays reachable.
     -->
     <div
       id="unsupported-browser-overlay"
@@ -412,6 +414,27 @@
       aria-labelledby="unsupported-browser-serial-title"
     >
       <div class="modal-card unsupported-browser-card">
+        <div id="unsupported-browser-ios-info" class="unsupported-browser-info" hidden>
+          <h2 id="unsupported-browser-ios-title">iPhone and iPad are not supported yet</h2>
+          <p>
+            Every browser on iOS and iPadOS is built on Apple's WebKit engine,
+            which offers neither Web Serial nor WebUSB — so installing Chrome,
+            Edge or Firefox here will not help. Connect, Download Radio and
+            Upload Radio cannot work on this device today.
+          </p>
+          <p>
+            We are working on a workaround so that iOS devices can talk to
+            radios; until then, program your radio from a desktop or Android
+            browser with
+            <a href="https://caniuse.com/web-serial" target="_blank" rel="noopener noreferrer"
+              >Web Serial support</a
+            >.
+          </p>
+          <p>
+            Everything file-based still works here: you can browse the radio
+            catalog and edit channels from an imported CSV or binary codeplug.
+          </p>
+        </div>
         <div id="unsupported-browser-serial-info" class="unsupported-browser-info" hidden>
           <h2 id="unsupported-browser-serial-title">This browser cannot program radios</h2>
           <p>

--- a/web/js/ui/dom.js
+++ b/web/js/ui/dom.js
@@ -30,6 +30,7 @@ export const REQUIRED_ELEMENTS = {
   // overlay explains why serial cannot work here.
   appShellEl: "#app-shell",
   unsupportedBrowserOverlayEl: "#unsupported-browser-overlay",
+  unsupportedBrowserIosInfoEl: "#unsupported-browser-ios-info",
   unsupportedBrowserSerialInfoEl: "#unsupported-browser-serial-info",
   unsupportedBrowserJspiInfoEl: "#unsupported-browser-jspi-info",
   unsupportedBrowserContinueEl: "#unsupported-browser-continue",

--- a/web/js/ui/format.js
+++ b/web/js/ui/format.js
@@ -112,6 +112,18 @@ export function isAndroidPlatform() {
   return /\bAndroid\b/i.test(navigator.userAgent || "");
 }
 
+// Every iOS/iPadOS browser is WebKit under the hood, so neither Web Serial nor
+// WebUSB is reachable there whatever browser the user installs — the generic
+// "try another browser" advice would be wrong. iPadOS reports a desktop
+// Macintosh user agent, so touch points are what separate it from a real Mac.
+export function isIosPlatform() {
+  const ua = navigator.userAgent || "";
+  if (/iPhone|iPad|iPod/i.test(ua)) {
+    return true;
+  }
+  return /Macintosh/i.test(ua) && (navigator.maxTouchPoints || 0) > 1;
+}
+
 export function flagEmojiFromCountryCode(countryCode) {
   const code = String(countryCode || "").trim().toUpperCase();
   const emojiCode = code === "UK" ? "GB" : code;

--- a/web/js/ui/serial-actions.js
+++ b/web/js/ui/serial-actions.js
@@ -1,4 +1,4 @@
-import { errorSummary, isAndroidPlatform, makeModelLabel } from "./format.js";
+import { errorSummary, isAndroidPlatform, isIosPlatform, makeModelLabel } from "./format.js";
 import {
   classifyErrorKind,
   codeplugParams,
@@ -121,18 +121,26 @@ export function createSerialActions(ctx) {
   // them together so the page never ends up grey with no explanation (or the
   // reverse). `problems` picks which explanations the card shows — they are
   // independent, not variants: Safari lacks both serial transports AND WASM
-  // stack switching, so both blocks appear there at once.
+  // stack switching, so both blocks appear there at once. iOS/iPadOS is the
+  // exception: whatever the capability gap is there, it is the platform rather
+  // than the browser choice, so its block replaces both generic ones instead
+  // of telling people to install a browser that would be the same WebKit.
   function setBrowserUnsupportedOverlayVisible(visible, problems = { serial: true }) {
     const show = Boolean(visible);
-    const serialShown = Boolean(problems.serial);
-    const jspiShown = Boolean(problems.jspi);
+    const iosShown = isIosPlatform();
+    const serialShown = !iosShown && Boolean(problems.serial);
+    const jspiShown = !iosShown && Boolean(problems.jspi);
+    dom.unsupportedBrowserIosInfoEl.hidden = !iosShown;
     dom.unsupportedBrowserSerialInfoEl.hidden = !serialShown;
     dom.unsupportedBrowserJspiInfoEl.hidden = !jspiShown;
     // Label the dialog by the more fundamental problem when both apply.
-    dom.unsupportedBrowserOverlayEl.setAttribute(
-      "aria-labelledby",
-      jspiShown ? "unsupported-browser-jspi-title" : "unsupported-browser-serial-title",
-    );
+    let labelledBy = "unsupported-browser-serial-title";
+    if (iosShown) {
+      labelledBy = "unsupported-browser-ios-title";
+    } else if (jspiShown) {
+      labelledBy = "unsupported-browser-jspi-title";
+    }
+    dom.unsupportedBrowserOverlayEl.setAttribute("aria-labelledby", labelledBy);
     dom.unsupportedBrowserOverlayEl.classList.toggle("hidden", !show);
     dom.appShellEl.classList.toggle("browser-unsupported", show);
   }


### PR DESCRIPTION
## What

iPhone and iPad users hitting the unsupported-browser overlay were told to install Chrome, Edge or Firefox — advice that cannot help, since every iOS/iPadOS browser is WebKit underneath and none of them expose Web Serial or WebUSB.

The overlay now shows a dedicated iOS block **instead of** the generic serial and JSPI blocks when it detects the platform. It names the platform (not the browser choice) as the limitation, says a workaround is being worked on, and points at the file-based features that do still work there.

## Changes

- `web/index.html` — new `#unsupported-browser-ios-info` block: "iPhone and iPad are not supported yet".
- `web/js/ui/format.js` — `isIosPlatform()`, matching iPhone/iPad/iPod plus iPadOS's desktop-Macintosh UA via `navigator.maxTouchPoints > 1`.
- `web/js/ui/serial-actions.js` — on iOS the new block replaces both generic ones; `aria-labelledby` points at the iOS title in that case.
- `web/js/ui/dom.js` — element lookup.

## Dependencies

None added.

## Testing

- `npm test` — 553 + 11 tests pass.
- Checked `isIosPlatform()` against four user agents: iPhone → true, iPadOS (touch Macintosh UA) → true, desktop Mac Safari → false (still gets the serial + JSPI blocks), Android Chrome → false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUsfV51cYAC7H7ud5BJ6M2