### PR TITLE
Keep Report Bug visible while Debug Output is folded

### DIFF
--- a/scripts/test-dom-selectors.mjs
+++ b/scripts/test-dom-selectors.mjs
@@ -113,3 +113,23 @@ test("queryUiElements reports every missing element at once", async () => {
     globalThis.document = previousDocument;
   }
 });
+
+// #debug-actions is toggled hidden with the Debug Output disclosure, so any
+// control that must stay reachable while the panel is folded has to live
+// outside it. Report Bug is that control: a user who cannot open the panel is
+// exactly the user with something to report.
+test("Report Bug sits outside the collapsible debug actions", () => {
+  const actionsAt = HTML.indexOf('id="debug-actions"');
+  assert.ok(actionsAt > 0, "index.html has no #debug-actions container");
+  const actionsEnd = HTML.indexOf("</div>", actionsAt);
+  const collapsible = HTML.slice(actionsAt, actionsEnd);
+
+  assert.ok(
+    !collapsible.includes('id="report-issue"'),
+    "#report-issue is inside #debug-actions and disappears when Debug Output is folded",
+  );
+  assert.ok(
+    /<div id="debug-actions"[^>]*\shidden/.test(HTML),
+    "#debug-actions is expected to start hidden; this test's premise no longer holds",
+  );
+});

--- a/web/index.html
+++ b/web/index.html
@@ -326,10 +326,18 @@
               Debug Output
             </button>
           </h2>
-          <div id="debug-actions" class="debug-actions" hidden>
+          <!--
+            Report Bug lives outside #debug-actions on purpose: a user who hits
+            a problem must be able to report it without first discovering the
+            disclosure. Copy and Clear only mean anything with the log on
+            screen, so they stay inside the collapsible group.
+          -->
+          <div class="debug-header-actions">
             <button id="report-issue" type="button">Report Bug</button>
-            <button id="debug-copy" type="button">Copy</button>
-            <button id="debug-clear" type="button">Clear</button>
+            <div id="debug-actions" class="debug-actions" hidden>
+              <button id="debug-copy" type="button">Copy</button>
+              <button id="debug-clear" type="button">Clear</button>
+            </div>
           </div>
         </div>
         <div id="debug-output-content" class="debug-output-content" hidden>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1262,8 +1262,10 @@ button:disabled {
   gap: 0.75rem;
 }
 
+.debug-header-actions,
 .debug-actions {
   display: inline-flex;
+  align-items: center;
   gap: 0.5rem;
 }
 
@@ -1658,7 +1660,7 @@ button:disabled {
   #channel-menu-toggle,
   .channel-menu-popup button,
   .modal-actions button,
-  .debug-actions button {
+  .debug-header-actions button {
     min-height: 2.75rem;
   }
 


### PR DESCRIPTION
## What changed

`Report Bug` lived inside `#debug-actions`, the container the Debug Output disclosure hides whenever the panel is collapsed. Since the panel starts folded, the button was only reachable after a user found and opened the disclosure.

It now sits in an always-visible `.debug-header-actions` wrapper alongside the collapsible group. `Copy` and `Clear` stay inside `#debug-actions`, because neither means anything without the log on screen.

- `web/index.html` — `#report-issue` moved out of `#debug-actions`; the collapsible group now nests inside the new wrapper.
- `web/styles.css` — the wrapper shares the existing `inline-flex` / `0.5rem` gap rule so spacing is identical folded or expanded; the mobile touch-target rule follows the button to `.debug-header-actions button` so it keeps its 2.75rem target.
- `scripts/test-dom-selectors.mjs` — structural regression test asserting `#report-issue` is not inside the hidden container, plus a second assertion that fails loudly if `#debug-actions` ever stops starting hidden, so the test cannot silently become vacuous.

## Why

The user most likely to need the bug reporter is the one who just hit a problem — and that is exactly the user least likely to go hunting through a collapsed disclosure to find it. Reporting with an empty log is safe: `issue-report.js` already substitutes a `<no debug logs captured>` placeholder.

No logic changed. `debug-log.js` still toggles a single container; this is purely a regrouping of which controls live inside it.

## Reviewer notes

- `aria-controls="debug-actions debug-output-content"` is unchanged and still accurate — `#debug-actions` still exists and is still exactly what the toggle governs. The new wrapper is a layout node with no ARIA role.
- Styling is untouched: the button keeps its existing amber `--warn-btn-*` treatment. Making it red was considered and deliberately rejected — red in this codebase means "your data is invalid" (invalid settings fields, invalid grid cells, failed loopback rows), never "press this", and the button is now permanently on screen, where saturated red would be alarm fatigue.

## Verification

- Full `npm test` passes (syntax, pyright, channels, webusb, settings, build) with 0 failures.
- Checked in-browser: folded desktop shows Report Bug alone on the right; expanded shows Report Bug / Copy / Clear evenly spaced; mobile at 375px keeps the 44px touch target with no horizontal overflow.

## Dependencies

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)