### PR TITLE
Guard the repeater query form against a second in-flight submit

### DIFF
--- a/scripts/test-ui-repeater-modal.mjs
+++ b/scripts/test-ui-repeater-modal.mjs
@@ -740,6 +740,32 @@ function installRsgbFetch(bySquare) {
   return calls;
 }
 
+// Like installRsgbFetch, but every response waits on a gate the test opens.
+// That holds a query in flight for as long as the test needs, which is what it
+// takes to land a second submit on the first one — the double-click the
+// in-flight guard exists to absorb.
+function installGatedRsgbFetch(bySquare) {
+  const calls = [];
+  let openGate;
+  const gate = new Promise((resolve) => {
+    openGate = resolve;
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (url, init) => {
+      calls.push({ url: String(url), init });
+      await gate;
+      const square = String(url).split("/").pop();
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: bySquare[square] ?? null }),
+      };
+    },
+  });
+  return { calls, release: () => openGate() };
+}
+
 function repeaterRecord(overrides = {}) {
   return {
     id: 199,
@@ -869,6 +895,9 @@ test("a coordinate-free or ill-formed RSGB query never reaches the network", asy
 
   assert.deepEqual(calls, [], "nothing should have been fetched");
   assert.equal(dom.repeaterQueryModalEl.classList.contains("hidden"), false, "the modal stays open on an error");
+  // Four submits were accepted, so a failed query must release the in-flight
+  // guard rather than leaving the form wedged.
+  assert.equal(dom.repeaterQuerySubmitEl.disabled, false, "a failed query leaves the button usable");
 });
 
 test("an RSGB query fans out over the squares and inserts the matching repeaters", async () => {
@@ -1065,4 +1094,34 @@ test("an RSGB query with no channel schema loaded does nothing", async () => {
   assert.deepEqual(calls, []);
   assert.deepEqual(table.inserted, []);
   assert.ok(log.statuses.includes("No channel schema loaded yet."));
+});
+
+test("a second submit while a query is in flight is ignored, not duplicated", async () => {
+  const { dom, log, table } = buildHarness();
+  installGeolocation(LONDON);
+  const { calls, release } = installGatedRsgbFetch({
+    IO91: [repeaterRecord({ id: 1, repeater: "GB3XP", tx: 145687500, rx: 145087500, locator: "IO91VJ" })],
+    JO01: [repeaterRecord({ id: 2, repeater: "GB3BK", tx: 430900000, rx: 438500000, locator: "JO01AK", band: "70CM" })],
+  });
+
+  await openRsgb(dom);
+  await geolocateButton(dom).dispatch("click");
+
+  // Not awaited: the query is suspended on the gated fetch, exactly as it is
+  // suspended on a real fan-out that takes seconds.
+  const first = dom.repeaterQueryFormEl.dispatch("submit");
+  assert.equal(dom.repeaterQuerySubmitEl.disabled, true, "the button says the query is running");
+  assert.equal(dom.repeaterQuerySubmitEl.textContent, "Querying...");
+
+  const second = dom.repeaterQueryFormEl.dispatch("submit");
+  release();
+  await Promise.all([first, second]);
+
+  assert.deepEqual(log.errors, []);
+  assert.equal(table.inserted.length, 1, "the second submit must not insert a second copy");
+  assert.deepEqual(table.inserted[0].rows.map((row) => row.Name), ["GB3XP", "GB3BK"]);
+  // Two squares for London at 30 km: the second submit fanned out over none.
+  assert.equal(calls.length, 2, "the second submit must not reach the network");
+  assert.equal(dom.repeaterQuerySubmitEl.disabled, false, "the button comes back for the next query");
+  assert.equal(dom.repeaterQuerySubmitEl.textContent, "Query API");
 });

--- a/web/js/ui/repeater-query.js
+++ b/web/js/ui/repeater-query.js
@@ -60,6 +60,23 @@ export function createRepeaterQuery(ctx) {
   let fieldInstances = [];
   let positionField = null;
   const positionState = { latitudeText: "", longitudeText: "" };
+  // True while a query is awaiting its network round-trip. The submit handler
+  // is async, so without this a second submit re-enters it while the first is
+  // suspended, and both resolved queries insert their rows — every repeater
+  // twice. An RSGB fan-out over 24 squares takes seconds, so the window is
+  // wide enough to hit by double-clicking.
+  let queryInFlight = false;
+  const submitIdleLabel = dom.repeaterQuerySubmitEl.textContent || "Query API";
+
+  // Mark the query busy: the flag is what actually rejects a re-entrant
+  // submit (Enter in a text field submits the form too, not just the button),
+  // while the disabled button and its label are how the user sees why the
+  // second click did nothing.
+  function setQueryBusy(busy) {
+    queryInFlight = busy;
+    dom.repeaterQuerySubmitEl.disabled = busy;
+    dom.repeaterQuerySubmitEl.textContent = busy ? "Querying..." : submitIdleLabel;
+  }
 
   function buildFields(source, loadedOptions) {
     dom.repeaterQueryGridEl.innerHTML = "";
@@ -195,6 +212,10 @@ export function createRepeaterQuery(ctx) {
     });
     dom.repeaterQueryFormEl.addEventListener("submit", async (event) => {
       event.preventDefault();
+      if (queryInFlight) {
+        return;
+      }
+      setQueryBusy(true);
       try {
         if (!state.currentHeaders.length) {
           log.setStatus("No channel schema loaded yet.");
@@ -205,6 +226,8 @@ export function createRepeaterQuery(ctx) {
         setModalOpen(false);
       } catch (error) {
         log.reportActionError(`${activeSource.actionLabel} query`, error);
+      } finally {
+        setQueryBusy(false);
       }
     });
   }


### PR DESCRIPTION
Fixes https://github.com/jasiek/webchirp/issues/105.

## The bug

`repeater-query.js`'s form `submit` listener is `async`, so `await activeSource.runQuery(...)` returns control to the event loop. Nothing stopped a second `submit` from re-entering the handler while the first was suspended: both queries resolved, both called `insertRowsAtSelectionOrEnd`, and every repeater landed twice. An RSGB fan-out over 24 locator squares takes seconds, so double-clicking "Query API" hits it easily. The same applied to przemienniki, RepeaterBook and IRTS, since all four share the one modal.

## The fix

- A module-scoped `queryInFlight` flag rejects a re-entrant submit. The flag, not the button state, is the authoritative check — pressing Enter in a text field submits the form too.
- `dom.repeaterQuerySubmitEl` (declared in `dom.js` but never referenced until now) is disabled and relabelled "Querying..." while the query runs, so the user can see why a second click does nothing.
- The reset lives in a `finally`, so a failed, rejected or browser-timed-out query leaves the form usable for a retry instead of wedged. The modal already stays open on an error, so retrying is in place.

## Tests

- New test in `scripts/test-ui-repeater-modal.mjs`: a gated fetch holds a query in flight while a second submit is dispatched, then asserts one insert, one fan-out, and the button restored to "Query API". Verified it fails against the unfixed handler (two inserts) and passes with the guard.
- The existing "coordinate-free or ill-formed RSGB query" test now also asserts the button is re-enabled after a failed submit, covering the `finally` path.
- Full `npm test` green: 1105 tests, 0 failures, plus the syntax and pyright checks.

## Dependencies

None added.

## Noted but out of scope

None of the three `fetch` call sites in this path use an `AbortController`/`AbortSignal.timeout`, so there is no application-level timeout — a hung proxy leaves the button reading "Querying..." until the browser's own network timeout fires. Pre-existing, and worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)