### PR TITLE
Simplify the webchirp_bridge package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ This repository hosts a browser-based CHIRP interface (`web/`) that executes CHI
   the canonical form is anchored away from that and is checked by
   `test-build-dist.mjs`, which also fails when a rename leaves a path behind.
 - Python functions must have type signatures.
+- An import used only in annotations goes under `if TYPE_CHECKING:` so it adds no
+  runtime dependency; every module has `from __future__ import annotations`, which is
+  what makes that safe. Type radio-shaped parameters with the CHIRP class, not `Any`.
 - Avoid context pollution by spawning sub-agents when appropriate.
   - Use sub-agent sandboxing when a read-only task is to be executed.
   - Use sub-agents to produce a summary for a commit message.

--- a/web/python/runtime_bridge.py
+++ b/web/python/runtime_bridge.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 # has to be a global even though no bridge module needs it.
 import json  # noqa: F401
 import sys
-import types
-from typing import Any
+from typing import TYPE_CHECKING
 
 # The package and the seeded CHIRP sources both live under this directory (the
 # JS side writes them there); the guard keeps a re-run from stacking entries.
@@ -42,6 +41,10 @@ from webchirp_bridge import (  # noqa: E402
     runtime_errors,
     serial_pipe,
 )
+
+if TYPE_CHECKING:
+    import types
+    from typing import Any
 
 # Every module whose names make up the RPC namespace, the package itself
 # included for the shims it installs. Order is irrelevant: no two modules

--- a/web/python/webchirp_bridge/__init__.py
+++ b/web/python/webchirp_bridge/__init__.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 import builtins
 import sys
 import types
-from typing import Any
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from typing import Any
 
 def _install_gettext_builtins() -> None:
     """Provide the translation builtins CHIRP expects from its wx frontend.

--- a/web/python/webchirp_bridge/channel_rows.py
+++ b/web/python/webchirp_bridge/channel_rows.py
@@ -10,7 +10,7 @@ under ``ROW_EXTRA_KEY`` and are applied to memories here as well.
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from chirp import (
     chirp_common,
@@ -28,23 +28,23 @@ from webchirp_bridge.power_levels import (
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 
 if TYPE_CHECKING:
-    from typing import Optional, Sequence
+    from typing import Any, Optional, Sequence
 
-# A channel as it crosses the JS/Python boundary: one JSON object per channel,
-# keyed by CSV header name (``CSV_HEADERS`` below, from
-# ``chirp_common.Memory.CSV_FORMAT``) with text values — "Location": "25",
-# "Frequency": "443.000000", "Duplex": "+". It is the grid's row, serialized by
-# ``setRowsJsonGlobal()`` in ``web/js/runtime-rpc.js`` and parsed here with
-# ``json.loads``, so every value a header names is a string.
-#
-# The value type is ``Any`` rather than ``str`` because a row may also carry
-# non-header keys the editor rides along on it — currently the ``__geo``
-# sidecar (``web/js/row-geo.js``), an object, which is why the type cannot
-# promise ``str`` for arbitrary keys. Nothing in the runtime reads those: every
-# consumer projects a row through ``CSV_HEADERS`` and ignores the rest, which is
-# what keeps the sidecar out of a codeplug.
-Row = dict[str, Any]
-Rows = list[Row]
+    # A channel as it crosses the JS/Python boundary: one JSON object per channel,
+    # keyed by CSV header name (``CSV_HEADERS`` below, from
+    # ``chirp_common.Memory.CSV_FORMAT``) with text values — "Location": "25",
+    # "Frequency": "443.000000", "Duplex": "+". It is the grid's row, serialized by
+    # ``setRowsJsonGlobal()`` in ``web/js/runtime-rpc.js`` and parsed here with
+    # ``json.loads``, so every value a header names is a string.
+    #
+    # The value type is ``Any`` rather than ``str`` because a row may also carry
+    # non-header keys the editor rides along on it — currently the ``__geo``
+    # sidecar (``web/js/row-geo.js``), an object, which is why the type cannot
+    # promise ``str`` for arbitrary keys. Nothing in the runtime reads those: every
+    # consumer projects a row through ``CSV_HEADERS`` and ignores the rest, which is
+    # what keeps the sidecar out of a codeplug.
+    Row = dict[str, Any]
+    Rows = list[Row]
 
 # Driver extras ride on channel rows under a key that is not a CSV header, the
 # same way repeater coordinates do in web/js/row-geo.js. Everything that

--- a/web/python/webchirp_bridge/channel_rows.py
+++ b/web/python/webchirp_bridge/channel_rows.py
@@ -10,7 +10,7 @@ under ``ROW_EXTRA_KEY`` and are applied to memories here as well.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Any, TYPE_CHECKING
 
 from chirp import (
     chirp_common,
@@ -27,6 +27,8 @@ from webchirp_bridge.power_levels import (
 )
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 
+if TYPE_CHECKING:
+    from typing import Optional, Sequence
 
 # A channel as it crosses the JS/Python boundary: one JSON object per channel,
 # keyed by CSV header name (``CSV_HEADERS`` below, from

--- a/web/python/webchirp_bridge/channel_rows.py
+++ b/web/python/webchirp_bridge/channel_rows.py
@@ -153,7 +153,7 @@ def _row_int(text: Any, fallback: int, label: str) -> int:
 
 
 def _memory_from_row_values(
-    vals: Sequence[Any], level_map: Optional[dict[str, Any]] = None
+    vals: Sequence[Any], level_map: Optional[dict[str, chirp_common.PowerLevel]] = None
 ) -> chirp_common.Memory:
     """Build a Memory from row values, inverting chirp_common.Memory.to_csv().
 

--- a/web/python/webchirp_bridge/channel_rows.py
+++ b/web/python/webchirp_bridge/channel_rows.py
@@ -92,6 +92,16 @@ def _row_values_for_csv(mem: chirp_common.Memory) -> list[Any]:
     return mem.to_csv()
 
 
+def _row_text_values(mem: chirp_common.Memory) -> list[str]:
+    """A memory's CSV fields as the text the grid shows, in ``CSV_HEADERS`` order."""
+    return [str(value) for value in _row_values_for_csv(mem)]
+
+
+def _row_from_memory(mem: chirp_common.Memory) -> Row:
+    """Project a memory onto a grid row: CSV header names to text values."""
+    return dict(zip(CSV_HEADERS, _row_text_values(mem)))
+
+
 def get_default_headers() -> dict[str, Any]:
     """Channel columns to show before a radio or codeplug decides them.
 
@@ -111,10 +121,7 @@ def parse_csv(csv_text: str) -> dict[str, Any]:
     for mem in radio.memories:
         if mem.empty:
             continue
-        row: Row = {}
-        for header, value in zip(CSV_HEADERS, _row_values_for_csv(mem)):
-            row[header] = str(value)
-        rows.append(row)
+        rows.append(_row_from_memory(mem))
 
     return {
         "headers": CSV_HEADERS,

--- a/web/python/webchirp_bridge/chirp_loader.py
+++ b/web/python/webchirp_bridge/chirp_loader.py
@@ -16,8 +16,7 @@ import importlib.abc
 import os
 import sys
 import traceback
-import types
-from typing import Any, Callable, Iterable, Optional, Sequence
+from typing import TYPE_CHECKING
 
 from chirp import (
     chirp_common,
@@ -26,6 +25,10 @@ from chirp import (
 from js import fetch_chirp_source
 
 from webchirp_bridge.jsbridge import _await_js, _js_to_py, _log_debug
+
+if TYPE_CHECKING:
+    import types
+    from typing import Any, Callable, Iterable, Optional, Sequence
 
 
 def _chirp_source_relpath(fullname: str) -> str:

--- a/web/python/webchirp_bridge/chirp_loader.py
+++ b/web/python/webchirp_bridge/chirp_loader.py
@@ -25,7 +25,7 @@ from chirp import (
 )
 from js import fetch_chirp_source
 
-from webchirp_bridge.jsbridge import _await_js, _log_debug
+from webchirp_bridge.jsbridge import _await_js, _js_to_py, _log_debug
 
 
 def _chirp_source_relpath(fullname: str) -> str:
@@ -52,9 +52,7 @@ def _ensure_chirp_module_file(fullname: str) -> None:
     if os.path.exists(runtime_path):
         return
     source_relpath = _chirp_source_relpath(fullname)
-    source = _await_js(fetch_chirp_source(source_relpath))
-    if hasattr(source, "to_py"):
-        source = source.to_py()
+    source = _js_to_py(_await_js(fetch_chirp_source(source_relpath)))
     os.makedirs(os.path.dirname(runtime_path), exist_ok=True)
     with open(runtime_path, "w", encoding="utf-8") as f:
         f.write(str(source))

--- a/web/python/webchirp_bridge/clone.py
+++ b/web/python/webchirp_bridge/clone.py
@@ -15,7 +15,7 @@ from typing import Any, Optional, Sequence
 from chirp import chirp_common
 from js import serial_prepare_clone
 
-from webchirp_bridge.channel_rows import CSV_HEADERS, Rows, normalize_rows
+from webchirp_bridge.channel_rows import Rows, normalize_rows
 from webchirp_bridge.driver_cache import (
     LAST_IMAGE_BY_DRIVER,
     _cache_driver_image,
@@ -23,12 +23,11 @@ from webchirp_bridge.driver_cache import (
     _driver_cache_key,
     _import_radio_class,
     _radio_from_image_bytes,
-    _record_unreadable_channels,
 )
 from webchirp_bridge.jsbridge import _await_js, _log_debug, _make_status_logger
 from webchirp_bridge.radio_memories import (
     _apply_rows_to_radio_instance,
-    _radio_rows_from_instance,
+    _read_radio_payload,
 )
 from webchirp_bridge.radio_settings import _validate_and_apply_radio_settings
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
@@ -159,19 +158,9 @@ def _download_selected_radio_sync(module_name: str, class_name: str) -> dict[str
     radio.sync_in()
     # The image belongs to whatever detection settled on, not to the selection
     # the user made in the UI, and upload/export have to re-parse it as such.
-    _cache_driver_image(module_name, class_name, radio)
-
-    rows, unreadable = _radio_rows_from_instance(radio)
-    _record_unreadable_channels(module_name, class_name, unreadable)
-    csv_text = normalize_rows(rows, module_name, class_name)
-    settings_result = _validate_and_apply_radio_settings(radio, [], apply_changes=False)
-    return {
-        "rows": rows,
-        "headers": CSV_HEADERS,
-        "csvText": csv_text,
-        "settings": settings_result["settings"],
-        "unreadableChannels": unreadable,
-    }
+    payload = _read_radio_payload(module_name, class_name, radio)
+    payload["csvText"] = normalize_rows(payload["rows"], module_name, class_name)
+    return payload
 
 
 def _upload_selected_radio_sync(

--- a/web/python/webchirp_bridge/clone.py
+++ b/web/python/webchirp_bridge/clone.py
@@ -10,12 +10,13 @@ is never written from a blank instance.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING
+
 
 from chirp import chirp_common
 from js import serial_prepare_clone
 
-from webchirp_bridge.channel_rows import Rows, normalize_rows
+from webchirp_bridge.channel_rows import normalize_rows
 from webchirp_bridge.driver_cache import (
     LAST_IMAGE_BY_DRIVER,
     _cache_driver_image,
@@ -33,6 +34,9 @@ from webchirp_bridge.radio_settings import _validate_and_apply_radio_settings
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 from webchirp_bridge.serial_pipe import WebSerialPipe, _serial_pipe_timeout_seconds
 
+if TYPE_CHECKING:
+    from typing import Any, Optional, Sequence
+    from webchirp_bridge.channel_rows import Rows
 
 def _ensure_clone_mode_radio(radio_cls: type[chirp_common.Radio]) -> None:
     """Enforce clone-mode driver requirement for live serial workflows."""

--- a/web/python/webchirp_bridge/clone.py
+++ b/web/python/webchirp_bridge/clone.py
@@ -34,7 +34,7 @@ from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 from webchirp_bridge.serial_pipe import WebSerialPipe, _serial_pipe_timeout_seconds
 
 
-def _ensure_clone_mode_radio(radio_cls: type) -> None:
+def _ensure_clone_mode_radio(radio_cls: type[chirp_common.Radio]) -> None:
     """Enforce clone-mode driver requirement for live serial workflows."""
     if not issubclass(radio_cls, chirp_common.CloneModeRadio):
         raise RuntimeUnsupportedError(
@@ -42,7 +42,7 @@ def _ensure_clone_mode_radio(radio_cls: type) -> None:
         )
 
 
-def _driver_baud_rate(radio_cls: Any) -> Optional[int]:
+def _driver_baud_rate(radio_cls: type[chirp_common.Radio]) -> Optional[int]:
     """Return the driver's declared serial line rate, or None when unusable.
 
     CHIRP drivers advertise BAUD_RATE as a plain class attribute, so it can be
@@ -130,7 +130,7 @@ def _create_radio_for_serial(radio_cls: type[chirp_common.Radio]) -> chirp_commo
     return radio
 
 
-def _prepare_clone_session(radio_cls: Any) -> None:
+def _prepare_clone_session(radio_cls: type[chirp_common.Radio]) -> None:
     """Reset/prepare transport lines before clone operations for stability.
 
     Also hands the bridge the driver's declared BAUD_RATE. The port's line rate

--- a/web/python/webchirp_bridge/column_metadata.py
+++ b/web/python/webchirp_bridge/column_metadata.py
@@ -8,7 +8,7 @@ ever runs.
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 from chirp import chirp_common
 
@@ -31,6 +31,25 @@ def _radio_supports_dv(rf: Any) -> bool:
     return "DV" in modes
 
 
+def _enum_column(editable: Any, values: Optional[Iterable[Any]]) -> dict[str, Any]:
+    """An enumerated column: the grid offers exactly the driver's values."""
+    return {"kind": "enum", "editable": bool(editable), "options": _mk_enum(values)}
+
+
+def _formatted_enum_column(
+    editable: Any, values: Optional[Iterable[Any]], fmt: str, convert: Callable[[Any], Any]
+) -> dict[str, Any]:
+    """An enumerated column of numbers, spelled the way an exported CSV spells them."""
+    options = [fmt.format(convert(value)) for value in (values or [])]
+    return {"kind": "enum", "editable": bool(editable), "options": options}
+
+
+def _freq_column(editable: Any, rf: Any) -> dict[str, Any]:
+    """A frequency column constrained to the radio's bands."""
+    bands = [[int(low), int(high)] for (low, high) in (rf.valid_bands or [])]
+    return {"kind": "freq", "editable": bool(editable), "bands": bands}
+
+
 def get_radio_column_metadata(module_name: str, class_name: str) -> dict[str, Any]:
     """Build CHIRP-derived column editability/options metadata for the UI."""
     radio_cls = _import_radio_class(module_name, class_name)
@@ -38,103 +57,48 @@ def get_radio_column_metadata(module_name: str, class_name: str) -> dict[str, An
     rf = radio.get_features()
     lo, hi = rf.memory_bounds
 
-    col = {}
-    col["Location"] = {
-        "kind": "int",
-        "editable": False,
-        "min": int(lo),
-        "max": int(hi),
-    }
-    col["Name"] = {
-        "kind": "text",
-        "editable": bool(rf.has_name),
-        "maxLength": int(rf.valid_name_length),
-        "validChars": str(rf.valid_characters),
-    }
-    col["Frequency"] = {
-        "kind": "freq",
-        "editable": True,
-        "bands": [[int(a), int(b)] for (a, b) in (rf.valid_bands or [])],
-    }
-    col["Duplex"] = {
-        "kind": "enum",
-        "editable": True,
-        "options": _mk_enum(rf.valid_duplexes),
-    }
-    col["Offset"] = {
-        "kind": "freq",
-        "editable": bool(rf.has_offset),
-        "bands": [[int(a), int(b)] for (a, b) in (rf.valid_bands or [])],
-    }
-    col["Tone"] = {
-        "kind": "enum",
-        "editable": True,
-        "options": _mk_enum(rf.valid_tmodes),
-    }
-    col["rToneFreq"] = {
-        "kind": "enum",
-        "editable": True,
-        "options": [f"{float(x):.1f}" for x in (rf.valid_tones or [])],
-    }
-    col["cToneFreq"] = {
-        "kind": "enum",
-        "editable": bool(rf.has_ctone),
-        "options": [f"{float(x):.1f}" for x in (rf.valid_tones or [])],
-    }
-    col["DtcsCode"] = {
-        "kind": "enum",
-        "editable": bool(rf.has_dtcs),
-        "options": [f"{int(x):03d}" for x in (rf.valid_dtcs_codes or [])],
-    }
-    col["RxDtcsCode"] = {
-        "kind": "enum",
-        "editable": bool(rf.has_rx_dtcs),
-        "options": [f"{int(x):03d}" for x in (rf.valid_dtcs_codes or [])],
-    }
-    col["DtcsPolarity"] = {
-        "kind": "enum",
-        "editable": bool(rf.has_dtcs_polarity),
-        "options": _mk_enum(rf.valid_dtcs_pols),
-    }
-    col["CrossMode"] = {
-        "kind": "enum",
-        "editable": bool(rf.has_cross),
-        "options": _mk_enum(rf.valid_cross_modes),
-    }
-    col["Mode"] = {
-        "kind": "enum",
-        "editable": bool(rf.has_mode),
-        "options": _mk_enum(rf.valid_modes),
-    }
-    col["TStep"] = {
-        "kind": "enum",
-        "editable": bool(rf.has_tuning_step),
-        "options": [f"{float(x):.2f}" for x in (rf.valid_tuning_steps or [])],
-    }
-    col["Skip"] = {
-        "kind": "enum",
-        "editable": True,
-        "options": _mk_enum(rf.valid_skips),
-    }
-    col["Power"] = {
-        "kind": "enum",
-        "editable": True,
-        "options": _mk_enum(rf.valid_power_levels),
-        "optionWatts": _power_level_watts(rf.valid_power_levels),
-    }
-    col["Comment"] = {
-        "kind": "text",
-        # Clone-mode radios without native comments use CHIRP's image metadata
-        # hooks, so their comments are just as editable as driver-backed ones.
-        "editable": bool(
-            rf.has_comment
-            or isinstance(radio, chirp_common.ExternalMemoryProperties)
+    col: dict[str, Any] = {
+        "Location": {"kind": "int", "editable": False, "min": int(lo), "max": int(hi)},
+        "Name": {
+            "kind": "text",
+            "editable": bool(rf.has_name),
+            "maxLength": int(rf.valid_name_length),
+            "validChars": str(rf.valid_characters),
+        },
+        "Frequency": _freq_column(True, rf),
+        "Duplex": _enum_column(True, rf.valid_duplexes),
+        "Offset": _freq_column(rf.has_offset, rf),
+        "Tone": _enum_column(True, rf.valid_tmodes),
+        "rToneFreq": _formatted_enum_column(True, rf.valid_tones, "{:.1f}", float),
+        "cToneFreq": _formatted_enum_column(rf.has_ctone, rf.valid_tones, "{:.1f}", float),
+        "DtcsCode": _formatted_enum_column(rf.has_dtcs, rf.valid_dtcs_codes, "{:03d}", int),
+        "RxDtcsCode": _formatted_enum_column(
+            rf.has_rx_dtcs, rf.valid_dtcs_codes, "{:03d}", int
         ),
+        "DtcsPolarity": _enum_column(rf.has_dtcs_polarity, rf.valid_dtcs_pols),
+        "CrossMode": _enum_column(rf.has_cross, rf.valid_cross_modes),
+        "Mode": _enum_column(rf.has_mode, rf.valid_modes),
+        "TStep": _formatted_enum_column(
+            rf.has_tuning_step, rf.valid_tuning_steps, "{:.2f}", float
+        ),
+        "Skip": _enum_column(True, rf.valid_skips),
+        "Power": {
+            **_enum_column(True, rf.valid_power_levels),
+            "optionWatts": _power_level_watts(rf.valid_power_levels),
+        },
+        "Comment": {
+            "kind": "text",
+            # Clone-mode radios without native comments use CHIRP's image
+            # metadata hooks, so their comments are just as editable as
+            # driver-backed ones.
+            "editable": bool(
+                rf.has_comment
+                or isinstance(radio, chirp_common.ExternalMemoryProperties)
+            ),
+        },
     }
-    col["URCALL"] = {"kind": "text", "editable": False}
-    col["RPT1CALL"] = {"kind": "text", "editable": False}
-    col["RPT2CALL"] = {"kind": "text", "editable": False}
-    col["DVCODE"] = {"kind": "text", "editable": False}
+    for header in DV_ONLY_HEADERS:
+        col[header] = {"kind": "text", "editable": False}
 
     headers = list(CSV_HEADERS)
     if not _radio_supports_dv(rf):

--- a/web/python/webchirp_bridge/column_metadata.py
+++ b/web/python/webchirp_bridge/column_metadata.py
@@ -25,26 +25,26 @@ def _mk_enum(values: Optional[Iterable[Any]]) -> list[str]:
     return [str(v) for v in values] if values else []
 
 
-def _radio_supports_dv(rf: Any) -> bool:
+def _radio_supports_dv(rf: chirp_common.RadioFeatures) -> bool:
     """Detect whether a radio's mode capabilities include D-STAR DV mode."""
     modes = {str(mode) for mode in (rf.valid_modes or [])}
     return "DV" in modes
 
 
-def _enum_column(editable: Any, values: Optional[Iterable[Any]]) -> dict[str, Any]:
+def _enum_column(editable: bool, values: Optional[Iterable[Any]]) -> dict[str, Any]:
     """An enumerated column: the grid offers exactly the driver's values."""
     return {"kind": "enum", "editable": bool(editable), "options": _mk_enum(values)}
 
 
 def _formatted_enum_column(
-    editable: Any, values: Optional[Iterable[Any]], fmt: str, convert: Callable[[Any], Any]
+    editable: bool, values: Optional[Iterable[Any]], fmt: str, convert: Callable[[Any], Any]
 ) -> dict[str, Any]:
     """An enumerated column of numbers, spelled the way an exported CSV spells them."""
     options = [fmt.format(convert(value)) for value in (values or [])]
     return {"kind": "enum", "editable": bool(editable), "options": options}
 
 
-def _freq_column(editable: Any, rf: Any) -> dict[str, Any]:
+def _freq_column(editable: bool, rf: chirp_common.RadioFeatures) -> dict[str, Any]:
     """A frequency column constrained to the radio's bands."""
     bands = [[int(low), int(high)] for (low, high) in (rf.valid_bands or [])]
     return {"kind": "freq", "editable": bool(editable), "bands": bands}

--- a/web/python/webchirp_bridge/column_metadata.py
+++ b/web/python/webchirp_bridge/column_metadata.py
@@ -8,7 +8,8 @@ ever runs.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Optional
+from typing import TYPE_CHECKING
+
 
 from chirp import chirp_common
 
@@ -16,6 +17,8 @@ from webchirp_bridge.channel_rows import CSV_HEADERS
 from webchirp_bridge.driver_cache import _blank_radio_instance, _import_radio_class
 from webchirp_bridge.power_levels import _power_level_watts
 
+if TYPE_CHECKING:
+    from typing import Any, Callable, Iterable, Optional
 
 DV_ONLY_HEADERS = ["URCALL", "RPT1CALL", "RPT2CALL", "DVCODE"]
 

--- a/web/python/webchirp_bridge/column_metadata.py
+++ b/web/python/webchirp_bridge/column_metadata.py
@@ -13,7 +13,7 @@ from typing import Any, Iterable, Optional
 from chirp import chirp_common
 
 from webchirp_bridge.channel_rows import CSV_HEADERS
-from webchirp_bridge.driver_cache import _import_radio_class
+from webchirp_bridge.driver_cache import _blank_radio_instance, _import_radio_class
 from webchirp_bridge.power_levels import _power_level_watts
 
 
@@ -34,10 +34,7 @@ def _radio_supports_dv(rf: Any) -> bool:
 def get_radio_column_metadata(module_name: str, class_name: str) -> dict[str, Any]:
     """Build CHIRP-derived column editability/options metadata for the UI."""
     radio_cls = _import_radio_class(module_name, class_name)
-    try:
-        radio = radio_cls(None)
-    except Exception:
-        radio = radio_cls("")
+    radio = _blank_radio_instance(radio_cls)
     rf = radio.get_features()
     lo, hi = rf.memory_bounds
 

--- a/web/python/webchirp_bridge/driver_cache.py
+++ b/web/python/webchirp_bridge/driver_cache.py
@@ -136,8 +136,8 @@ def _protected_channels(module_name: str, class_name: str) -> set[int]:
 
 
 def _cached_image_class(
-    module_name: str, class_name: str, radio_cls: type
-) -> type:
+    module_name: str, class_name: str, radio_cls: type[chirp_common.Radio]
+) -> type[chirp_common.Radio]:
     """Return the class that should re-parse this driver key's cached image.
 
     Falls back to the selected class when nothing has been cached under this

--- a/web/python/webchirp_bridge/driver_cache.py
+++ b/web/python/webchirp_bridge/driver_cache.py
@@ -43,6 +43,20 @@ IMAGE_CLASS_BY_DRIVER: dict[str, type] = {}
 UNREADABLE_BY_DRIVER: dict[str, set[int]] = {}
 
 
+def _blank_radio_instance(radio_cls: type[chirp_common.Radio]) -> chirp_common.Radio:
+    """Instantiate a driver with no image, the way CHIRP's model picker does.
+
+    radio_cls(None) is the documented blank constructor, but a few drivers
+    only accept a path-like argument and fail on None; the empty string is the
+    fallback that gets those to a usable blank state (FINDINGS:
+    blank-instances-misreport-state).
+    """
+    try:
+        return radio_cls(None)
+    except Exception:
+        return radio_cls("")
+
+
 def _driver_features(module_name: str, class_name: str) -> Optional[chirp_common.RadioFeatures]:
     """Return a driver's RadioFeatures, preferring the cached image.
 
@@ -197,12 +211,6 @@ def _best_effort_radio_instance(
     driver_key = _driver_cache_key(module_name, class_name)
     base_image = LAST_IMAGE_BY_DRIVER.get(driver_key)
 
-    def _fallback_constructor() -> chirp_common.Radio:
-        try:
-            return radio_cls(None)
-        except Exception:
-            return radio_cls("")
-
     if base_image is not None:
         radio = _radio_from_image_bytes(
             _cached_image_class(module_name, class_name, radio_cls), base_image
@@ -216,9 +224,9 @@ def _best_effort_radio_instance(
                 "No cached radio image for this model. Download from radio first."
             )
         else:
-            radio = _fallback_constructor()
+            radio = _blank_radio_instance(radio_cls)
     else:
-        radio = _fallback_constructor()
+        radio = _blank_radio_instance(radio_cls)
 
     radio.status_fn = _make_status_logger()
     return radio

--- a/web/python/webchirp_bridge/driver_cache.py
+++ b/web/python/webchirp_bridge/driver_cache.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import contextlib
 import os
 import tempfile
-from typing import Iterator, Optional, Sequence
+from typing import TYPE_CHECKING
 
 from chirp import (
     chirp_common,
@@ -27,6 +27,8 @@ from chirp import (
 from webchirp_bridge.jsbridge import _make_status_logger
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 
+if TYPE_CHECKING:
+    from typing import Iterator, Optional, Sequence
 
 LAST_IMAGE_BY_DRIVER = {}
 # Which class actually produced/parses LAST_IMAGE_BY_DRIVER[key]. Serial

--- a/web/python/webchirp_bridge/driver_cache.py
+++ b/web/python/webchirp_bridge/driver_cache.py
@@ -14,9 +14,10 @@ state live here too.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import tempfile
-from typing import Optional, Sequence
+from typing import Iterator, Optional, Sequence
 
 from chirp import (
     chirp_common,
@@ -134,6 +135,30 @@ def _cached_image_class(
     )
 
 
+@contextlib.contextmanager
+def _temp_image_path(
+    data: Optional[bytes] = None, prefix: str = "webchirp-cache-"
+) -> Iterator[str]:
+    """A throwaway .img path for CHIRP to read or write, removed on exit.
+
+    CHIRP only parses bytes through a driver's own loader (``radio_cls(path)``),
+    detects a radio (``get_radio_by_image``) or serializes (``save_mmap``) via a
+    file path, so every image that passes through the runtime takes this
+    detour. ``data`` seeds the file when CHIRP is the one reading it.
+    """
+    with tempfile.NamedTemporaryFile(
+        mode="wb", suffix=".img", prefix=prefix, delete=False
+    ) as image_file:
+        image_path = image_file.name
+        if data is not None:
+            image_file.write(bytes(data))
+    try:
+        yield image_path
+    finally:
+        with contextlib.suppress(Exception):
+            os.unlink(image_path)
+
+
 def _radio_from_image_bytes(
     radio_cls: type[chirp_common.Radio], image_bytes: bytes
 ) -> chirp_common.Radio:
@@ -142,18 +167,8 @@ def _radio_from_image_bytes(
     This keeps reconstruction paired with ``_image_bytes_from_radio`` and lets
     each driver apply its normal file parsing and metadata handling.
     """
-    with tempfile.NamedTemporaryFile(
-        mode="wb", suffix=".img", prefix="webchirp-cache-", delete=False
-    ) as image_file:
-        image_path = image_file.name
-        image_file.write(bytes(image_bytes))
-    try:
+    with _temp_image_path(image_bytes) as image_path:
         return radio_cls(image_path)
-    finally:
-        try:
-            os.unlink(image_path)
-        except Exception:
-            pass
 
 
 def _image_bytes_from_radio(radio: chirp_common.Radio) -> bytes:
@@ -162,19 +177,10 @@ def _image_bytes_from_radio(radio: chirp_common.Radio) -> bytes:
     Icom's ``get_mmap`` may flip high bits for clone transport, while
     ``save_mmap`` writes the internal file representation expected on reload.
     """
-    with tempfile.NamedTemporaryFile(
-        suffix=".img", prefix="webchirp-cache-", delete=False
-    ) as image_file:
-        image_path = image_file.name
-    try:
+    with _temp_image_path() as image_path:
         radio.save_mmap(image_path)
         with open(image_path, "rb") as image_file:
             return image_file.read()
-    finally:
-        try:
-            os.unlink(image_path)
-        except Exception:
-            pass
 
 
 def _has_cached_image(module_name: str, class_name: str) -> bool:

--- a/web/python/webchirp_bridge/images.py
+++ b/web/python/webchirp_bridge/images.py
@@ -10,8 +10,6 @@ settings before serializing it, the same way an upload would.
 from __future__ import annotations
 
 import base64
-import os
-import tempfile
 from typing import Any, Optional, Sequence
 
 from chirp import (
@@ -34,6 +32,7 @@ from webchirp_bridge.driver_cache import (
     _import_radio_class,
     _radio_from_image_bytes,
     _record_unreadable_channels,
+    _temp_image_path,
 )
 from webchirp_bridge.jsbridge import _make_status_logger
 from webchirp_bridge.radio_memories import (
@@ -161,21 +160,11 @@ def load_image_base64(image_b64: str) -> dict[str, Any]:
     """Load a CHIRP .img payload, detect driver, and return rows + radio identity."""
     raw_image = _decode_image_b64(image_b64)
 
-    with tempfile.NamedTemporaryFile(
-        mode="wb", suffix=".img", prefix="webchirp-", delete=False
-    ) as f:
-        image_path = f.name
-        f.write(raw_image)
-
-    try:
-        radio = directory.get_radio_by_image(image_path)
-    except Exception as exc:
-        raise ImageDetectionError(f"Unable to detect radio from image: {exc}") from exc
-    finally:
+    with _temp_image_path(raw_image, prefix="webchirp-") as image_path:
         try:
-            os.unlink(image_path)
-        except Exception:
-            pass
+            radio = directory.get_radio_by_image(image_path)
+        except Exception as exc:
+            raise ImageDetectionError(f"Unable to detect radio from image: {exc}") from exc
 
     if not isinstance(radio, chirp_common.CloneModeRadio):
         raise RuntimeUnsupportedError("Loaded image is not a clone-mode CHIRP image")

--- a/web/python/webchirp_bridge/images.py
+++ b/web/python/webchirp_bridge/images.py
@@ -44,6 +44,19 @@ from webchirp_bridge.radio_settings import _validate_and_apply_radio_settings
 from webchirp_bridge.runtime_errors import ImageDetectionError, RuntimeUnsupportedError
 
 
+def _decode_image_b64(image_b64: str) -> bytes:
+    """Decode an image the browser sent as base64, refusing a malformed payload."""
+    try:
+        return base64.b64decode(str(image_b64 or ""), validate=True)
+    except Exception as exc:
+        raise RuntimeUnsupportedError("Invalid image base64 payload") from exc
+
+
+def _image_payload(image: bytes) -> dict[str, Any]:
+    """The two fields every image-returning reply shares: base64 text and byte size."""
+    return {"imageBase64": base64.b64encode(bytes(image)).decode("ascii"), "size": len(image)}
+
+
 def get_cached_image_base64(module_name: str, class_name: str) -> dict[str, Any]:
     """Return cached clone image bytes for a driver as base64 text."""
     driver_key = _driver_cache_key(module_name, class_name)
@@ -52,20 +65,14 @@ def get_cached_image_base64(module_name: str, class_name: str) -> dict[str, Any]
         raise RuntimeUnsupportedError(
             "No cached radio image for this model. Download from radio first."
         )
-    return {
-        "imageBase64": base64.b64encode(bytes(image)).decode("ascii"),
-        "size": len(image),
-    }
+    return _image_payload(image)
 
 
 def upload_image_base64(module_name: str, class_name: str, image_b64: str) -> dict[str, Any]:
     """Upload an explicit full-image payload through the selected clone driver."""
     radio_cls = _import_radio_class(module_name, class_name)
     _ensure_clone_mode_radio(radio_cls)
-    try:
-        raw_image = base64.b64decode(str(image_b64 or ""), validate=True)
-    except Exception as exc:
-        raise RuntimeUnsupportedError("Invalid image base64 payload") from exc
+    raw_image = _decode_image_b64(image_b64)
 
     radio = _radio_from_image_bytes(radio_cls, raw_image)
     radio.status_fn = _make_status_logger()
@@ -117,8 +124,7 @@ def export_image_base64(
         else _image_bytes_from_radio(radio)
     )
     return {
-        "imageBase64": base64.b64encode(image_data).decode("ascii"),
-        "size": len(image_data),
+        **_image_payload(image_data),
         "vendor": str(getattr(radio_cls, "VENDOR", "")),
         "model": str(getattr(radio_cls, "MODEL", "")),
         "variant": str(getattr(radio_cls, "VARIANT", "")),
@@ -128,10 +134,7 @@ def export_image_base64(
 
 def read_image_metadata_base64(image_b64: str) -> dict[str, Any]:
     """Parse the CHIRP metadata trailer from a .img payload without importing drivers."""
-    try:
-        raw_image = base64.b64decode(str(image_b64 or ""), validate=True)
-    except Exception as exc:
-        raise RuntimeUnsupportedError("Invalid image base64 payload") from exc
+    raw_image = _decode_image_b64(image_b64)
 
     _, metadata = chirp_common.CloneModeRadio._strip_metadata(raw_image)
     if not metadata:
@@ -156,10 +159,7 @@ def read_image_metadata_base64(image_b64: str) -> dict[str, Any]:
 
 def load_image_base64(image_b64: str) -> dict[str, Any]:
     """Load a CHIRP .img payload, detect driver, and return rows + radio identity."""
-    try:
-        raw_image = base64.b64decode(str(image_b64 or ""), validate=True)
-    except Exception as exc:
-        raise RuntimeUnsupportedError("Invalid image base64 payload") from exc
+    raw_image = _decode_image_b64(image_b64)
 
     with tempfile.NamedTemporaryFile(
         mode="wb", suffix=".img", prefix="webchirp-", delete=False

--- a/web/python/webchirp_bridge/images.py
+++ b/web/python/webchirp_bridge/images.py
@@ -10,14 +10,13 @@ settings before serializing it, the same way an upload would.
 from __future__ import annotations
 
 import base64
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING
 
 from chirp import (
     chirp_common,
     directory,
 )
 
-from webchirp_bridge.channel_rows import Rows
 from webchirp_bridge.clone import (
     _ensure_clone_mode_radio,
     _new_serial_pipe,
@@ -41,6 +40,9 @@ from webchirp_bridge.radio_memories import (
 from webchirp_bridge.radio_settings import _validate_and_apply_radio_settings
 from webchirp_bridge.runtime_errors import ImageDetectionError, RuntimeUnsupportedError
 
+if TYPE_CHECKING:
+    from typing import Any, Optional, Sequence
+    from webchirp_bridge.channel_rows import Rows
 
 def _decode_image_b64(image_b64: str) -> bytes:
     """Decode an image the browser sent as base64, refusing a malformed payload."""

--- a/web/python/webchirp_bridge/images.py
+++ b/web/python/webchirp_bridge/images.py
@@ -17,7 +17,7 @@ from chirp import (
     directory,
 )
 
-from webchirp_bridge.channel_rows import CSV_HEADERS, Rows
+from webchirp_bridge.channel_rows import Rows
 from webchirp_bridge.clone import (
     _ensure_clone_mode_radio,
     _new_serial_pipe,
@@ -31,13 +31,12 @@ from webchirp_bridge.driver_cache import (
     _image_bytes_from_radio,
     _import_radio_class,
     _radio_from_image_bytes,
-    _record_unreadable_channels,
     _temp_image_path,
 )
 from webchirp_bridge.jsbridge import _make_status_logger
 from webchirp_bridge.radio_memories import (
     _apply_rows_to_radio_instance,
-    _radio_rows_from_instance,
+    _read_radio_payload,
 )
 from webchirp_bridge.radio_settings import _validate_and_apply_radio_settings
 from webchirp_bridge.runtime_errors import ImageDetectionError, RuntimeUnsupportedError
@@ -172,18 +171,11 @@ def load_image_base64(image_b64: str) -> dict[str, Any]:
     base_cls = getattr(radio.__class__, "_orig_rclass", radio.__class__)
     module_short = str(base_cls.__module__).rsplit(".", 1)[-1]
     class_name = str(base_cls.__name__)
-    _cache_driver_image(module_short, class_name, radio)
-    rows, unreadable = _radio_rows_from_instance(radio)
-    _record_unreadable_channels(module_short, class_name, unreadable)
-    settings_result = _validate_and_apply_radio_settings(radio, [], apply_changes=False)
     return {
         "module": module_short,
         "className": class_name,
         "vendor": str(getattr(radio.__class__, "VENDOR", "")),
         "model": str(getattr(radio.__class__, "MODEL", "")),
         "variant": str(getattr(radio.__class__, "VARIANT", "")),
-        "rows": rows,
-        "headers": CSV_HEADERS,
-        "settings": settings_result["settings"],
-        "unreadableChannels": unreadable,
+        **_read_radio_payload(module_short, class_name, radio),
     }

--- a/web/python/webchirp_bridge/jsbridge.py
+++ b/web/python/webchirp_bridge/jsbridge.py
@@ -11,13 +11,15 @@ shows the user -- the debug panel (``_log_debug``) and the progress strip
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable
+from typing import TYPE_CHECKING
 
 from js import (
     serial_log,
     serial_progress,
 )
 
+if TYPE_CHECKING:
+    from typing import Any, Callable
 
 try:
     from pyodide.ffi import run_sync as pyodide_run_sync

--- a/web/python/webchirp_bridge/power_levels.py
+++ b/web/python/webchirp_bridge/power_levels.py
@@ -11,13 +11,16 @@ the mapping.
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional
+from typing import TYPE_CHECKING
+
 
 from chirp import chirp_common
 
 from webchirp_bridge.driver_cache import _driver_features
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 
+if TYPE_CHECKING:
+    from typing import Any, Iterable, Optional
 
 DEFAULT_EXPORT_POWER = "50W"
 

--- a/web/python/webchirp_bridge/power_levels.py
+++ b/web/python/webchirp_bridge/power_levels.py
@@ -79,6 +79,19 @@ def _power_levels_by_label(levels: Iterable[Any]) -> dict[str, Any]:
     return mapped
 
 
+def _level_map_for_radio(radio: Any, module_name: str, class_name: str) -> dict[str, Any]:
+    """Index the power levels a radio instance advertises, or its driver's if none.
+
+    A parsed image can advertise levels a blank instance does not (Rt98Radio),
+    so the instance wins; the driver lookup only fills in for a radio that
+    reports nothing, or for a preflight that runs before any instance exists.
+    """
+    levels = list(radio.get_features().valid_power_levels or []) if radio else []
+    return _power_levels_by_label(
+        levels or _valid_power_levels_for_driver(module_name, class_name)
+    )
+
+
 def _resolve_power_level(power_text: Any, level_map: dict[str, Any]) -> Any:
     """Resolve row power text to the driver's own PowerLevel object."""
     text = str(power_text or "").strip()

--- a/web/python/webchirp_bridge/power_levels.py
+++ b/web/python/webchirp_bridge/power_levels.py
@@ -22,7 +22,7 @@ from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 DEFAULT_EXPORT_POWER = "50W"
 
 
-def _watts_label(level: Any) -> str:
+def _watts_label(level: chirp_common.PowerLevel) -> str:
     """Format a power level's wattage the way CHIRP writes power into a CSV.
 
     ``float()``, not ``int()``: ``PowerLevel.__int__`` truncates the dBm, so a
@@ -33,7 +33,9 @@ def _watts_label(level: Any) -> str:
     )
 
 
-def _power_label_map_from_features(rf: Any) -> tuple[dict[str, str], str]:
+def _power_label_map_from_features(
+    rf: Optional[chirp_common.RadioFeatures],
+) -> tuple[dict[str, str], str]:
     """Map radio power labels (e.g., High) to CSV power specs (e.g., 50W)."""
     levels = (getattr(rf, "valid_power_levels", None) or []) if rf else []
 
@@ -51,13 +53,13 @@ def _power_label_map_from_features(rf: Any) -> tuple[dict[str, str], str]:
     return mapped, default_power
 
 
-def _valid_power_levels_for_driver(module_name: str, class_name: str) -> list[Any]:
+def _valid_power_levels_for_driver(module_name: str, class_name: str) -> list[chirp_common.PowerLevel]:
     """Return a driver's own PowerLevel objects, or an empty list if unavailable."""
     rf = _driver_features(module_name, class_name)
     return list(getattr(rf, "valid_power_levels", None) or []) if rf else []
 
 
-def _power_levels_by_label(levels: Iterable[Any]) -> dict[str, Any]:
+def _power_levels_by_label(levels: Iterable[chirp_common.PowerLevel]) -> dict[str, chirp_common.PowerLevel]:
     """Index a driver's PowerLevel objects by every label they round-trip as.
 
     Rows carry power as text: `Memory.to_csv()` writes the driver's own label
@@ -79,7 +81,9 @@ def _power_levels_by_label(levels: Iterable[Any]) -> dict[str, Any]:
     return mapped
 
 
-def _level_map_for_radio(radio: Any, module_name: str, class_name: str) -> dict[str, Any]:
+def _level_map_for_radio(
+    radio: Optional[chirp_common.Radio], module_name: str, class_name: str
+) -> dict[str, chirp_common.PowerLevel]:
     """Index the power levels a radio instance advertises, or its driver's if none.
 
     A parsed image can advertise levels a blank instance does not (Rt98Radio),
@@ -92,7 +96,9 @@ def _level_map_for_radio(radio: Any, module_name: str, class_name: str) -> dict[
     )
 
 
-def _resolve_power_level(power_text: Any, level_map: dict[str, Any]) -> Any:
+def _resolve_power_level(
+    power_text: Any, level_map: dict[str, chirp_common.PowerLevel]
+) -> Optional[chirp_common.PowerLevel]:
     """Resolve row power text to the driver's own PowerLevel object."""
     text = str(power_text or "").strip()
     # Memory.to_csv() renders an unset power as "%s" % None, so a channel that
@@ -149,7 +155,7 @@ def _csv_export_power_text(value: Any, power_map: dict[str, str]) -> str:
     return text
 
 
-def _power_level_watts(levels: Optional[Iterable[Any]]) -> dict[str, str]:
+def _power_level_watts(levels: Optional[Iterable[chirp_common.PowerLevel]]) -> dict[str, str]:
     """Map each advertised power level's label to its wattage.
 
     Driver labels carry no wattage — "L3" and "Mid1" say nothing on their own —

--- a/web/python/webchirp_bridge/power_levels.py
+++ b/web/python/webchirp_bridge/power_levels.py
@@ -107,13 +107,6 @@ def _power_label_map_for_radio(module_name: str, class_name: str) -> tuple[dict[
     """Map a selected driver's power labels to CSV power specs."""
     return _power_label_map_from_features(_driver_features(module_name, class_name))
 
-
-def _normalize_power_value(value: Any, power_map: dict[str, str], default_power: str) -> str:
-    """Return a CHIRP-parseable power value or blank if unavailable."""
-    text = str(value or "").strip()
-    fallback = default_power or DEFAULT_EXPORT_POWER
-    if not text:
-        return fallback
     if text in power_map:
         return power_map[text]
     try:

--- a/web/python/webchirp_bridge/radio_memories.py
+++ b/web/python/webchirp_bridge/radio_memories.py
@@ -12,14 +12,13 @@ driver that fails on hundreds of channels would otherwise bury it.
 from __future__ import annotations
 
 import traceback
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING
 
 from chirp import chirp_common
 
 from webchirp_bridge.channel_rows import (
     CSV_HEADERS,
     ROW_EXTRA_KEY,
-    Rows,
     _apply_row_extras,
     _coerce_csv_vals_for_chirp,
     _memory_from_row_values,
@@ -37,6 +36,9 @@ from webchirp_bridge.radio_settings import _validate_and_apply_radio_settings
 from webchirp_bridge.row_validation import _immutable_policy_errors, _prepare_row_change
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 
+if TYPE_CHECKING:
+    from typing import Any, Optional, Sequence
+    from webchirp_bridge.channel_rows import Rows
 
 def _iter_memory_numbers(radio: chirp_common.Radio) -> range:
     """Return numeric memory range for the active radio model."""

--- a/web/python/webchirp_bridge/radio_memories.py
+++ b/web/python/webchirp_bridge/radio_memories.py
@@ -19,13 +19,12 @@ from chirp import chirp_common
 from webchirp_bridge.channel_rows import (
     CSV_HEADERS,
     ROW_EXTRA_KEY,
-    Row,
     Rows,
     _apply_row_extras,
     _coerce_csv_vals_for_chirp,
     _memory_from_row_values,
     _row_extras_from_memory,
-    _row_values_for_csv,
+    _row_from_memory,
 )
 from webchirp_bridge.driver_cache import _protected_channels
 from webchirp_bridge.jsbridge import _log_debug
@@ -122,9 +121,7 @@ def _radio_rows_from_instance(radio: chirp_common.Radio) -> tuple[Rows, list[int
             continue
         if getattr(mem, "empty", False):
             continue
-        row: Row = {}
-        for header, value in zip(CSV_HEADERS, _row_values_for_csv(mem)):
-            row[header] = str(value)
+        row = _row_from_memory(mem)
         extras = _row_extras_from_memory(mem)
         if extras:
             row[ROW_EXTRA_KEY] = extras

--- a/web/python/webchirp_bridge/radio_memories.py
+++ b/web/python/webchirp_bridge/radio_memories.py
@@ -12,7 +12,7 @@ driver that fails on hundreds of channels would otherwise bury it.
 from __future__ import annotations
 
 import traceback
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from chirp import chirp_common
 
@@ -26,9 +26,14 @@ from webchirp_bridge.channel_rows import (
     _row_extras_from_memory,
     _row_from_memory,
 )
-from webchirp_bridge.driver_cache import _protected_channels
+from webchirp_bridge.driver_cache import (
+    _cache_driver_image,
+    _protected_channels,
+    _record_unreadable_channels,
+)
 from webchirp_bridge.jsbridge import _log_debug
 from webchirp_bridge.power_levels import _level_map_for_radio
+from webchirp_bridge.radio_settings import _validate_and_apply_radio_settings
 from webchirp_bridge.row_validation import _immutable_policy_errors, _prepare_row_change
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 
@@ -130,6 +135,28 @@ def _radio_rows_from_instance(radio: chirp_common.Radio) -> tuple[Rows, list[int
         trace_by_reason,
     )
     return rows, unreadable
+
+
+def _read_radio_payload(
+    module_name: str, class_name: str, radio: chirp_common.Radio
+) -> dict[str, Any]:
+    """Everything a freshly read radio hands the grid, plus the state it leaves.
+
+    The serial download and the image load differ only in how they obtained the
+    radio; from here on both cache its image under the driver key, extract the
+    rows, record the slots that would not decode so a later upload leaves them
+    alone, and serialize the radio-wide settings read-only.
+    """
+    _cache_driver_image(module_name, class_name, radio)
+    rows, unreadable = _radio_rows_from_instance(radio)
+    _record_unreadable_channels(module_name, class_name, unreadable)
+    settings_result = _validate_and_apply_radio_settings(radio, [], apply_changes=False)
+    return {
+        "rows": rows,
+        "headers": CSV_HEADERS,
+        "settings": settings_result["settings"],
+        "unreadableChannels": unreadable,
+    }
 
 
 def _apply_rows_to_radio_instance(

--- a/web/python/webchirp_bridge/radio_memories.py
+++ b/web/python/webchirp_bridge/radio_memories.py
@@ -28,10 +28,7 @@ from webchirp_bridge.channel_rows import (
 )
 from webchirp_bridge.driver_cache import _protected_channels
 from webchirp_bridge.jsbridge import _log_debug
-from webchirp_bridge.power_levels import (
-    _power_levels_by_label,
-    _valid_power_levels_for_driver,
-)
+from webchirp_bridge.power_levels import _level_map_for_radio
 from webchirp_bridge.row_validation import _immutable_policy_errors, _prepare_row_change
 from webchirp_bridge.runtime_errors import RuntimeUnsupportedError
 
@@ -143,10 +140,7 @@ def _apply_rows_to_radio_instance(
         radio_cls = radio.__class__
         module_name = module_name or str(getattr(radio_cls, "__module__", "")).split(".")[-1]
         class_name = class_name or str(getattr(radio_cls, "__name__", ""))
-    level_map = _power_levels_by_label(
-        list(radio.get_features().valid_power_levels or [])
-        or _valid_power_levels_for_driver(module_name, class_name)
-    )
+    level_map = _level_map_for_radio(radio, module_name, class_name)
     valid_numbers = set(_iter_memory_numbers(radio))
     seen_numbers = set()
     unreadable_erase_slots: dict[str, list[int]] = {}

--- a/web/python/webchirp_bridge/radio_memories.py
+++ b/web/python/webchirp_bridge/radio_memories.py
@@ -92,6 +92,27 @@ def _log_grouped_channel_failures(
         )
 
 
+def _read_memory(radio: chirp_common.Radio, number: int) -> chirp_common.Memory:
+    """Read one memory as CHIRP's editor sees it, external properties included.
+
+    Clone-mode radios keep comments outside driver memory, in the image
+    metadata; get_memory_extra is the post-read hook desktop CHIRP applies
+    so they appear on the memory like any other field. Raises whatever the
+    driver raises, so callers decide how a decode failure is recorded.
+    """
+    mem = radio.get_memory(number)
+    if isinstance(radio, chirp_common.ExternalMemoryProperties):
+        mem = radio.get_memory_extra(mem)
+    return mem
+
+
+def _erase_memory(radio: chirp_common.Radio, number: int) -> None:
+    """Erase one memory together with the external properties stored beside it."""
+    radio.erase_memory(number)
+    if isinstance(radio, chirp_common.ExternalMemoryProperties):
+        radio.erase_memory_extra(number)
+
+
 def _radio_rows_from_instance(radio: chirp_common.Radio) -> tuple[Rows, list[int]]:
     """Extract channel rows from a radio instance using CHIRP memory API.
 
@@ -108,11 +129,7 @@ def _radio_rows_from_instance(radio: chirp_common.Radio) -> tuple[Rows, list[int
     trace_by_reason: dict[str, str] = {}
     for number in _iter_memory_numbers(radio):
         try:
-            mem = radio.get_memory(number)
-            # CloneModeRadio stores comments outside driver memory in its image
-            # metadata, so mirror desktop CHIRP's post-read augmentation hook.
-            if isinstance(radio, chirp_common.ExternalMemoryProperties):
-                mem = radio.get_memory_extra(mem)
+            mem = _read_memory(radio, number)
         except Exception as exc:
             reason = str(exc) or exc.__class__.__name__
             unreadable.append(number)
@@ -185,11 +202,9 @@ def _apply_rows_to_radio_instance(
         seen_numbers.add(number)
         # CHIRP's immutable policy needs the current driver memory, not merely
         # the flattened grid row, before deciding whether a write is allowed.
-        existing = radio.get_memory(number)
         # External properties participate in row equality and immutable-field
         # validation even though the driver memory itself does not contain them.
-        if isinstance(radio, chirp_common.ExternalMemoryProperties):
-            existing = radio.get_memory_extra(existing)
+        existing = _read_memory(radio, number)
         vals = [str(row.get(h, "") or "") for h in CSV_HEADERS]
         vals = _coerce_csv_vals_for_chirp(vals)
         vals[0] = str(number)
@@ -207,9 +222,7 @@ def _apply_rows_to_radio_instance(
         for warning in warnings:
             _log_debug(f"Channel {number} validation warning: {warning}")
         if action == "erase":
-            radio.erase_memory(number)
-            if isinstance(radio, chirp_common.ExternalMemoryProperties):
-                radio.erase_memory_extra(number)
+            _erase_memory(radio, number)
         else:
             radio.set_memory(mem)
             _apply_row_extras(radio, number, row)
@@ -239,9 +252,7 @@ def _apply_rows_to_radio_instance(
             raise RuntimeUnsupportedError(
                 f"Channel {number}: {'; '.join(str(error) for error in validation_errors)}"
             )
-        radio.erase_memory(number)
-        if isinstance(radio, chirp_common.ExternalMemoryProperties):
-            radio.erase_memory_extra(number)
+        _erase_memory(radio, number)
 
     if protected:
         _log_debug(

--- a/web/python/webchirp_bridge/radio_settings.py
+++ b/web/python/webchirp_bridge/radio_settings.py
@@ -41,9 +41,47 @@ def _settings_unavailable_payload(
     }
 
 
+SETTINGS_NEED_IMAGE_MESSAGE = (
+    "Download from radio or load a codeplug image to edit radio-wide settings."
+)
+SETTINGS_NEED_STATE_MESSAGE = (
+    "Radio-wide settings are unavailable until this driver's backing state is loaded."
+)
+
+
+def _settings_validation_payload(
+    result: Optional[dict[str, Any]] = None,
+    *,
+    requires_image: bool = False,
+    message: str = "",
+    error_text: str = "",
+) -> dict[str, Any]:
+    """The validate_radio_settings reply.
+
+    result is the outcome of _validate_and_apply_radio_settings when the
+    settings could be checked; without it the reply says why they could not,
+    and reports the payload as valid so an unavailable panel never blocks an
+    upload of channels alone.
+    """
+    return {
+        "valid": bool(result["valid"]) if result is not None else True,
+        "issues": result["issues"] if result is not None else [],
+        "settings": result["settings"] if result is not None else [],
+        "available": result is not None,
+        "requiresImage": bool(requires_image),
+        "message": str(message or ""),
+        "error": str(error_text or ""),
+    }
+
+
 def _setting_path(parts: Iterable[Any]) -> list[str]:
     """Normalize a settings path list into a JSON-safe list of strings."""
     return [str(part) for part in parts]
+
+
+def _setting_issue(path: Sequence[Any], value_index: int, message: Any) -> dict[str, Any]:
+    """One settings finding: the setting's path, which of its values, and why."""
+    return {"path": _setting_path(path), "valueIndex": int(value_index), "message": str(message)}
 
 
 def _serialize_setting_value(value: Any) -> dict[str, Any]:
@@ -242,11 +280,9 @@ def _apply_serialized_settings(
         actual_child = _match_serialized_child(actual_children, child_id, position)
         if actual_child is None:
             issues.append(
-                {
-                    "path": _setting_path(prefix + [child_id]),
-                    "valueIndex": 0,
-                    "message": "Setting is not available for this radio image.",
-                }
+                _setting_issue(
+                    prefix + [child_id], 0, "Setting is not available for this radio image."
+                )
             )
             continue
 
@@ -257,11 +293,7 @@ def _apply_serialized_settings(
 
         if not isinstance(actual_child, chirp_settings.RadioSetting):
             issues.append(
-                {
-                    "path": _setting_path(path),
-                    "valueIndex": 0,
-                    "message": "Payload expected a setting but CHIRP returned a group.",
-                }
+                _setting_issue(path, 0, "Payload expected a setting but CHIRP returned a group.")
             )
             continue
 
@@ -291,26 +323,14 @@ def _apply_serialized_settings(
             # reports a malformed payload rather than a driver quirk.
             next_value = value_payload.get("current")
             if next_value is None:
-                issues.append(
-                    {
-                        "path": _setting_path(path),
-                        "valueIndex": int(value_index),
-                        "message": "Setting has no value to write.",
-                    }
-                )
+                issues.append(_setting_issue(path, value_index, "Setting has no value to write."))
                 continue
             if _serialized_value_matches(target, next_value):
                 continue
             try:
                 target.set_value(next_value)
             except Exception as exc:
-                issues.append(
-                    {
-                        "path": _setting_path(path),
-                        "valueIndex": int(value_index),
-                        "message": str(exc),
-                    }
-                )
+                issues.append(_setting_issue(path, value_index, exc))
 
 
 def _settings_child_is_writable(setting: Any) -> bool:
@@ -407,10 +427,7 @@ def get_radio_settings(module_name: str, class_name: str) -> dict[str, Any]:
     if issubclass(radio_cls, chirp_common.CloneModeRadio) and not _has_cached_image(
         module_name, class_name
     ):
-        return _settings_unavailable_payload(
-            "Download from radio or load a codeplug image to edit radio-wide settings.",
-            requires_image=True,
-        )
+        return _settings_unavailable_payload(SETTINGS_NEED_IMAGE_MESSAGE, requires_image=True)
 
     radio = _best_effort_radio_instance(module_name, class_name)
     rf = radio.get_features()
@@ -421,10 +438,7 @@ def get_radio_settings(module_name: str, class_name: str) -> dict[str, Any]:
     try:
         settings_tree = radio.get_settings()
     except Exception as exc:
-        return _settings_unavailable_payload(
-            "Radio-wide settings are unavailable until this driver's backing state is loaded.",
-            error_text=str(exc),
-        )
+        return _settings_unavailable_payload(SETTINGS_NEED_STATE_MESSAGE, error_text=str(exc))
     return {
         "supported": True,
         "available": True,
@@ -443,34 +457,14 @@ def validate_radio_settings(
     if issubclass(radio_cls, chirp_common.CloneModeRadio) and not _has_cached_image(
         module_name, class_name
     ):
-        return {
-            "valid": True,
-            "issues": [],
-            "settings": [],
-            "available": False,
-            "requiresImage": True,
-            "message": "Download from radio or load a codeplug image to edit radio-wide settings.",
-            "error": "",
-        }
+        return _settings_validation_payload(
+            requires_image=True, message=SETTINGS_NEED_IMAGE_MESSAGE
+        )
     radio = _best_effort_radio_instance(module_name, class_name, require_cached=False)
     try:
         result = _validate_and_apply_radio_settings(radio, settings_groups or [], apply_changes=False)
     except Exception as exc:
-        return {
-            "valid": True,
-            "issues": [],
-            "settings": [],
-            "available": False,
-            "requiresImage": False,
-            "message": "Radio-wide settings are unavailable until this driver's backing state is loaded.",
-            "error": str(exc),
-        }
-    return {
-        "valid": bool(result["valid"]),
-        "issues": result["issues"],
-        "settings": result["settings"],
-        "available": True,
-        "requiresImage": False,
-        "message": "",
-        "error": "",
-    }
+        return _settings_validation_payload(
+            message=SETTINGS_NEED_STATE_MESSAGE, error_text=str(exc)
+        )
+    return _settings_validation_payload(result)

--- a/web/python/webchirp_bridge/radio_settings.py
+++ b/web/python/webchirp_bridge/radio_settings.py
@@ -12,7 +12,7 @@ than guessing from a blank instance.
 from __future__ import annotations
 
 import copy
-from typing import Any, Iterable, Optional, Sequence, TypeAlias
+from typing import TYPE_CHECKING
 
 from chirp import (
     chirp_common,
@@ -26,11 +26,16 @@ from webchirp_bridge.driver_cache import (
 )
 from webchirp_bridge.jsbridge import _log_debug
 
+if TYPE_CHECKING:
+    from typing import Any, Iterable, Optional, Sequence, TypeAlias
 
-# What the settings walkers recurse over: the top-level RadioSettings is a
-# list subclass, every node below it is a RadioSettingGroup -- including
-# RadioSetting leaves, which CHIRP derives from the group class.
-SettingsContainer: TypeAlias = chirp_settings.RadioSettings | chirp_settings.RadioSettingGroup
+    # What the settings walkers recurse over: the top-level RadioSettings is a
+    # list subclass, every node below it is a RadioSettingGroup -- including
+    # RadioSetting leaves, which CHIRP derives from the group class. Only the
+    # checker needs the alias: annotations are lazy, so nothing reads it at runtime.
+    SettingsContainer: TypeAlias = (
+        chirp_settings.RadioSettings | chirp_settings.RadioSettingGroup
+    )
 
 
 def _settings_unavailable_payload(

--- a/web/python/webchirp_bridge/radio_settings.py
+++ b/web/python/webchirp_bridge/radio_settings.py
@@ -12,7 +12,7 @@ than guessing from a blank instance.
 from __future__ import annotations
 
 import copy
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Iterable, Optional, Sequence, TypeAlias
 
 from chirp import (
     chirp_common,
@@ -25,6 +25,12 @@ from webchirp_bridge.driver_cache import (
     _import_radio_class,
 )
 from webchirp_bridge.jsbridge import _log_debug
+
+
+# What the settings walkers recurse over: the top-level RadioSettings is a
+# list subclass, every node below it is a RadioSettingGroup -- including
+# RadioSetting leaves, which CHIRP derives from the group class.
+SettingsContainer: TypeAlias = chirp_settings.RadioSettings | chirp_settings.RadioSettingGroup
 
 
 def _settings_unavailable_payload(
@@ -84,7 +90,7 @@ def _setting_issue(path: Sequence[Any], value_index: int, message: Any) -> dict[
     return {"path": _setting_path(path), "valueIndex": int(value_index), "message": str(message)}
 
 
-def _serialize_setting_value(value: Any) -> dict[str, Any]:
+def _serialize_setting_value(value: chirp_settings.RadioSettingValue) -> dict[str, Any]:
     """Convert a CHIRP RadioSettingValue into UI-friendly JSON metadata."""
     current = value.get_value() if value.initialized else None
     data = {
@@ -137,7 +143,9 @@ def _serialize_setting_value(value: Any) -> dict[str, Any]:
     return data
 
 
-def _serialize_setting_node(node: Any, path_parts: list[Any]) -> dict[str, Any]:
+def _serialize_setting_node(
+    node: chirp_settings.RadioSettingGroup, path_parts: list[Any]
+) -> dict[str, Any]:
     """Serialize a CHIRP settings tree node for browser rendering."""
     if isinstance(node, chirp_settings.RadioSetting):
         raw_values = node.value if isinstance(node.value, list) else [node.value]
@@ -174,12 +182,16 @@ def _serialize_setting_node(node: Any, path_parts: list[Any]) -> dict[str, Any]:
     }
 
 
-def _serialize_radio_settings(settings_tree: Iterable[Any]) -> list[dict[str, Any]]:
+def _serialize_radio_settings(
+    settings_tree: Iterable[chirp_settings.RadioSettingGroup],
+) -> list[dict[str, Any]]:
     """Serialize the top-level RadioSettings collection."""
     return [_serialize_setting_node(group, []) for group in settings_tree]
 
 
-def _settings_container_children(container: Any) -> list[Any]:
+def _settings_container_children(
+    container: SettingsContainer,
+) -> list[chirp_settings.RadioSettingGroup]:
     """List a settings container's child nodes in tree order.
 
     CHIRP hands us three shapes of container and only two of them index by
@@ -195,8 +207,8 @@ def _settings_container_children(container: Any) -> list[Any]:
 
 
 def _match_serialized_child(
-    actual_children: Sequence[Any], child_id: str, position: int
-) -> Optional[Any]:
+    actual_children: Sequence[chirp_settings.RadioSettingGroup], child_id: str, position: int
+) -> Optional[chirp_settings.RadioSettingGroup]:
     """Resolve the CHIRP node a serialized child refers to, position first.
 
     Names are not unique: `kguv920pa.py:770` names its Repeater group
@@ -226,7 +238,9 @@ def _match_serialized_child(
     return named[0] if len(named) == 1 else None
 
 
-def _setting_value_at(setting: Any, value_index: int) -> Optional[Any]:
+def _setting_value_at(
+    setting: chirp_settings.RadioSetting, value_index: int
+) -> Optional[chirp_settings.RadioSettingValue]:
     """Return the CHIRP value object a serialized value index addresses."""
     try:
         return setting[value_index] if len(setting) > 1 else setting.value
@@ -234,7 +248,7 @@ def _setting_value_at(setting: Any, value_index: int) -> Optional[Any]:
         return None
 
 
-def _setting_value_is_mutable(setting: Any, value_index: int) -> bool:
+def _setting_value_is_mutable(setting: chirp_settings.RadioSetting, value_index: int) -> bool:
     """Report whether the selected CHIRP setting value accepts updates."""
     target = _setting_value_at(setting, value_index)
     if target is None:
@@ -242,7 +256,7 @@ def _setting_value_is_mutable(setting: Any, value_index: int) -> bool:
     return bool(getattr(target, "get_mutable", lambda: True)())
 
 
-def _serialized_value_matches(target: Any, next_value: Any) -> bool:
+def _serialized_value_matches(target: chirp_settings.RadioSettingValue, next_value: Any) -> bool:
     """Report whether a serialized value already equals CHIRP's current one.
 
     Writing back a value the driver itself emitted is a no-op at best and a
@@ -265,7 +279,7 @@ def _serialized_value_matches(target: Any, next_value: Any) -> bool:
 
 
 def _apply_serialized_settings(
-    actual_container: Any,
+    actual_container: SettingsContainer,
     payload_children: Optional[Sequence[Any]],
     issues: list[dict[str, Any]],
     prefix: list[str],
@@ -333,7 +347,7 @@ def _apply_serialized_settings(
                 issues.append(_setting_issue(path, value_index, exc))
 
 
-def _settings_child_is_writable(setting: Any) -> bool:
+def _settings_child_is_writable(setting: chirp_settings.RadioSettingGroup) -> bool:
     """Report whether CHIRP can write every value of one setting back.
 
     A value is unwritable when it is immutable, or when it never initialized:
@@ -353,7 +367,9 @@ def _settings_child_is_writable(setting: Any) -> bool:
     return True
 
 
-def _remove_settings_child(container: Any, element: Any) -> None:
+def _remove_settings_child(
+    container: SettingsContainer, element: chirp_settings.RadioSettingGroup
+) -> None:
     """Detach one child from whichever container shape CHIRP handed us.
 
     `RadioSettingGroup` deletes by element (`settings.py:591-593`), while a
@@ -365,7 +381,7 @@ def _remove_settings_child(container: Any, element: Any) -> None:
         container.remove(element)
 
 
-def _prune_dead_settings(container: Any) -> list[str]:
+def _prune_dead_settings(container: SettingsContainer) -> list[str]:
     """Drop settings CHIRP cannot write, and report what was dropped.
 
     Drivers differ in how defensive their `set_settings` is. `uv5r.py:2156`

--- a/web/python/webchirp_bridge/row_validation.py
+++ b/web/python/webchirp_bridge/row_validation.py
@@ -21,7 +21,8 @@ from webchirp_bridge.channel_rows import (
     Rows,
     _coerce_csv_vals_for_chirp,
     _memory_from_row_values,
-    _row_values_for_csv,
+    _row_from_memory,
+    _row_text_values,
 )
 from webchirp_bridge.driver_cache import _best_effort_radio_instance, _driver_features
 from webchirp_bridge.power_levels import (
@@ -145,10 +146,7 @@ def _preserve_unedited_immutable_fields(
         "power": "Power",
         "comment": "Comment",
     }
-    existing_row: dict[str, str] = {
-        header: str(value)
-        for header, value in zip(CSV_HEADERS, _row_values_for_csv(existing))
-    }
+    existing_row = _row_from_memory(existing)
     for field in list(getattr(existing, "immutable", None) or []):
         header = field_headers.get(field)
         if header and str(row.get(header, "") or "") == existing_row[header]:
@@ -234,7 +232,7 @@ def _memory_row_changed(
 def _row_matches_memory(row: Row, memory: chirp_common.Memory) -> bool:
     """Compare a grid row at exactly the fidelity exposed by the grid."""
     row_values = [str(row.get(header, "") or "") for header in CSV_HEADERS]
-    memory_values = [str(value) for value in _row_values_for_csv(memory)]
+    memory_values = _row_text_values(memory)
     return row_values == memory_values
 
 

--- a/web/python/webchirp_bridge/row_validation.py
+++ b/web/python/webchirp_bridge/row_validation.py
@@ -278,6 +278,11 @@ def _validation_column(message: ValidationMessage) -> str:
     return _infer_csv_error_column(text)
 
 
+def _issue(row_index: int, column: str, message: ValidationMessage) -> ValidationIssue:
+    """One preflight finding: the row, the grid column to mark, and the message."""
+    return {"rowIndex": int(row_index), "column": column, "message": str(message)}
+
+
 def validate_rows_for_upload(
     rows: Rows, module_name: str = "", class_name: str = ""
 ) -> dict[str, Any]:
@@ -308,25 +313,21 @@ def validate_rows_for_upload(
         if location is not None:
             if bounds and not (bounds[0] <= location <= bounds[1]):
                 issues.append(
-                    {
-                        "rowIndex": int(row_index),
-                        "column": "Location",
-                        "message": (
-                            f"Channel Location {location} is outside radio "
-                            f"memory bounds {bounds[0]}-{bounds[1]}"
-                        ),
-                    }
+                    _issue(
+                        row_index,
+                        "Location",
+                        f"Channel Location {location} is outside radio "
+                        f"memory bounds {bounds[0]}-{bounds[1]}",
+                    )
                 )
             elif location in seen_locations:
                 issues.append(
-                    {
-                        "rowIndex": int(row_index),
-                        "column": "Location",
-                        "message": (
-                            f"Channel Location {location} is already used by "
-                            f"row {seen_locations[location] + 1}"
-                        ),
-                    }
+                    _issue(
+                        row_index,
+                        "Location",
+                        f"Channel Location {location} is already used by "
+                        f"row {seen_locations[location] + 1}",
+                    )
                 )
             else:
                 seen_locations[location] = row_index
@@ -334,13 +335,7 @@ def validate_rows_for_upload(
             mem = _memory_from_row_values(vals, level_map)
         except Exception as exc:
             error_text = str(exc)
-            issues.append(
-                {
-                    "rowIndex": int(row_index),
-                    "column": _infer_csv_error_column(error_text),
-                    "message": error_text,
-                }
-            )
+            issues.append(_issue(row_index, _infer_csv_error_column(error_text), error_text))
             continue
 
         if (
@@ -360,19 +355,7 @@ def validate_rows_for_upload(
             row_warnings: list[str] = []
             row_errors: list[ValidationMessage] = [exc]
         for message in row_errors:
-            issues.append(
-                {
-                    "rowIndex": int(row_index),
-                    "column": _validation_column(message),
-                    "message": str(message),
-                }
-            )
+            issues.append(_issue(row_index, _validation_column(message), message))
         for message in row_warnings:
-            warnings.append(
-                {
-                    "rowIndex": int(row_index),
-                    "column": _validation_column(message),
-                    "message": str(message),
-                }
-            )
+            warnings.append(_issue(row_index, _validation_column(message), message))
     return {"valid": len(issues) == 0, "issues": issues, "warnings": warnings}

--- a/web/python/webchirp_bridge/row_validation.py
+++ b/web/python/webchirp_bridge/row_validation.py
@@ -37,6 +37,38 @@ ValidationIssue = dict[str, Any]
 ValidationMessage = str | Exception
 RowChangeAction = Literal["skip", "erase", "set"]
 
+# CHIRP Memory attribute -> the grid column (CSV header) that shows it, in
+# Memory.CSV_FORMAT order. Every translation between the driver's field
+# names and the grid's columns reads this one table, so a field listed here is
+# detected as a change, kept when immutable and reported in the right cell all
+# at once; the three copies this replaced could each drift on their own.
+MEMORY_FIELD_HEADERS: dict[str, str] = {
+    "name": "Name",
+    "freq": "Frequency",
+    "duplex": "Duplex",
+    "offset": "Offset",
+    "tmode": "Tone",
+    "rtone": "rToneFreq",
+    "ctone": "cToneFreq",
+    "dtcs": "DtcsCode",
+    "dtcs_polarity": "DtcsPolarity",
+    "rx_dtcs": "RxDtcsCode",
+    "cross_mode": "CrossMode",
+    "mode": "Mode",
+    "tuning_step": "TStep",
+    "skip": "Skip",
+    "power": "Power",
+    "comment": "Comment",
+}
+# Fields an immutable-field error can name that are not grid fields: number
+# is the row's Location, and empty has no column, so it lands on Frequency,
+# the cell that defines whether a channel exists.
+_ERROR_FIELD_COLUMNS: dict[str, str] = {
+    **MEMORY_FIELD_HEADERS,
+    "number": "Location",
+    "empty": "Frequency",
+}
+
 
 def _infer_csv_error_column(error_text: str) -> str:
     """Best-effort mapping from CHIRP parse error text to CSV column name."""
@@ -128,27 +160,9 @@ def _preserve_unedited_immutable_fields(
     reconstruct (notably fixed power levels). Comparing the source row avoids
     turning an edit to another column into an accidental immutable-field edit.
     """
-    field_headers: dict[str, str] = {
-        "name": "Name",
-        "freq": "Frequency",
-        "duplex": "Duplex",
-        "offset": "Offset",
-        "tmode": "Tone",
-        "rtone": "rToneFreq",
-        "ctone": "cToneFreq",
-        "dtcs": "DtcsCode",
-        "dtcs_polarity": "DtcsPolarity",
-        "rx_dtcs": "RxDtcsCode",
-        "cross_mode": "CrossMode",
-        "mode": "Mode",
-        "tuning_step": "TStep",
-        "skip": "Skip",
-        "power": "Power",
-        "comment": "Comment",
-    }
     existing_row = _row_from_memory(existing)
     for field in list(getattr(existing, "immutable", None) or []):
-        header = field_headers.get(field)
+        header = MEMORY_FIELD_HEADERS.get(field)
         if header and str(row.get(header, "") or "") == existing_row[header]:
             setattr(mem, field, getattr(existing, field))
 
@@ -195,25 +209,7 @@ def _memory_row_changed(
     existing: chirp_common.Memory, new: chirp_common.Memory
 ) -> bool:
     """Return whether any field represented by the channel grid changed."""
-    fields = (
-        "name",
-        "freq",
-        "duplex",
-        "offset",
-        "tmode",
-        "rtone",
-        "ctone",
-        "dtcs",
-        "dtcs_polarity",
-        "rx_dtcs",
-        "cross_mode",
-        "mode",
-        "tuning_step",
-        "skip",
-        "power",
-        "comment",
-        "empty",
-    )
+    fields = (*MEMORY_FIELD_HEADERS, "empty")
     for field in fields:
         existing_value = getattr(existing, field)
         new_value = getattr(new, field)
@@ -281,26 +277,7 @@ def _validation_column(message: ValidationMessage) -> str:
     text = str(message or "")
     match = re.search(r"Field ([A-Za-z_]+) is not mutable", text)
     if match:
-        return {
-            "number": "Location",
-            "name": "Name",
-            "freq": "Frequency",
-            "duplex": "Duplex",
-            "offset": "Offset",
-            "tmode": "Tone",
-            "rtone": "rToneFreq",
-            "ctone": "cToneFreq",
-            "dtcs": "DtcsCode",
-            "dtcs_polarity": "DtcsPolarity",
-            "rx_dtcs": "RxDtcsCode",
-            "cross_mode": "CrossMode",
-            "mode": "Mode",
-            "tuning_step": "TStep",
-            "skip": "Skip",
-            "power": "Power",
-            "comment": "Comment",
-            "empty": "Frequency",
-        }.get(match.group(1), "")
+        return _ERROR_FIELD_COLUMNS.get(match.group(1), "")
     return _infer_csv_error_column(text)
 
 

--- a/web/python/webchirp_bridge/row_validation.py
+++ b/web/python/webchirp_bridge/row_validation.py
@@ -11,7 +11,7 @@ preflight and the upload can never disagree about what a row means.
 from __future__ import annotations
 
 import re
-from typing import Any, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from chirp import chirp_common
 
@@ -26,14 +26,14 @@ from webchirp_bridge.driver_cache import _best_effort_radio_instance, _driver_fe
 from webchirp_bridge.power_levels import _level_map_for_radio
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Any, Literal, Optional
     from webchirp_bridge.channel_rows import Row, Rows
 
-# One invalid cell reported by the upload preflight: which row, which column,
-# and CHIRP's own message for it.
-ValidationIssue = dict[str, Any]
-ValidationMessage = str | Exception
-RowChangeAction = Literal["skip", "erase", "set"]
+    # One invalid cell reported by the upload preflight: which row, which column,
+    # and CHIRP's own message for it.
+    ValidationIssue = dict[str, Any]
+    ValidationMessage = str | Exception
+    RowChangeAction = Literal["skip", "erase", "set"]
 
 # CHIRP Memory attribute -> the grid column (CSV header) that shows it, in
 # Memory.CSV_FORMAT order. Every translation between the driver's field

--- a/web/python/webchirp_bridge/row_validation.py
+++ b/web/python/webchirp_bridge/row_validation.py
@@ -25,10 +25,7 @@ from webchirp_bridge.channel_rows import (
     _row_text_values,
 )
 from webchirp_bridge.driver_cache import _best_effort_radio_instance, _driver_features
-from webchirp_bridge.power_levels import (
-    _power_levels_by_label,
-    _valid_power_levels_for_driver,
-)
+from webchirp_bridge.power_levels import _level_map_for_radio
 
 
 # One invalid cell reported by the upload preflight: which row, which column,
@@ -290,10 +287,7 @@ def validate_rows_for_upload(
         if module_name and class_name
         else None
     )
-    levels = list(radio.get_features().valid_power_levels or []) if radio else []
-    level_map = _power_levels_by_label(
-        levels or _valid_power_levels_for_driver(module_name, class_name)
-    )
+    level_map = _level_map_for_radio(radio, module_name, class_name)
     # Location is checked here as well as in _apply_rows_to_radio_instance,
     # because that one raises partway through a clone: the radio is already
     # open and some memories written. Preflight is the only place a bad

--- a/web/python/webchirp_bridge/row_validation.py
+++ b/web/python/webchirp_bridge/row_validation.py
@@ -11,14 +11,12 @@ preflight and the upload can never disagree about what a row means.
 from __future__ import annotations
 
 import re
-from typing import Any, Literal, Optional
+from typing import Any, Literal, TYPE_CHECKING
 
 from chirp import chirp_common
 
 from webchirp_bridge.channel_rows import (
     CSV_HEADERS,
-    Row,
-    Rows,
     _coerce_csv_vals_for_chirp,
     _memory_from_row_values,
     _row_from_memory,
@@ -27,6 +25,9 @@ from webchirp_bridge.channel_rows import (
 from webchirp_bridge.driver_cache import _best_effort_radio_instance, _driver_features
 from webchirp_bridge.power_levels import _level_map_for_radio
 
+if TYPE_CHECKING:
+    from typing import Optional
+    from webchirp_bridge.channel_rows import Row, Rows
 
 # One invalid cell reported by the upload preflight: which row, which column,
 # and CHIRP's own message for it.

--- a/web/python/webchirp_bridge/serial_pipe.py
+++ b/web/python/webchirp_bridge/serial_pipe.py
@@ -11,7 +11,7 @@ loopback-probe entry points, which do not go through a driver at all.
 from __future__ import annotations
 
 import os
-from typing import Any, Optional
+from typing import TYPE_CHECKING
 
 from js import (
     serial_close,
@@ -28,6 +28,9 @@ from js import (
 )
 
 from webchirp_bridge.jsbridge import _await_js, _js_to_py, _log_debug
+
+if TYPE_CHECKING:
+    from typing import Any, Optional
 
 
 DEFAULT_SERIAL_PIPE_TIMEOUT = 1.2

--- a/web/python/webchirp_bridge/serial_pipe.py
+++ b/web/python/webchirp_bridge/serial_pipe.py
@@ -132,9 +132,7 @@ class WebSerialPipe:
     def read(self, count: int = 1) -> bytes:
         """Read up to count bytes from JS serial bridge with timeout semantics."""
         timeout_ms = max(1, int(float(self.timeout) * 1000))
-        data = _await_js(serial_read_bytes(int(count), timeout_ms))
-        if hasattr(data, "to_py"):
-            data = data.to_py()
+        data = _js_to_py(_await_js(serial_read_bytes(int(count), timeout_ms)))
         return bytes((int(x) & 0xFF) for x in data)
 
     def flush(self) -> None:


### PR DESCRIPTION
## Summary

Stacked on #154 (the package split); this PR only touches `web/python/webchirp_bridge/`. Eleven behaviour-preserving refactors, one commit each, taken from a read-only audit of the freshly split package. Every public function keeps its name, signature and JSON payload shape; the module graph stays acyclic. Net: 337 insertions, 408 deletions.

| Commit | What it removes |
| --- | --- |
| Use `_js_to_py` | two hand-rolled `hasattr(x, "to_py")` conversions |
| Remove `_normalize_power_value` | dead code, unreferenced in `web/`, `scripts/` and docs |
| Base64 helpers in `images.py` | three copies of the decode-or-raise block, two of the `imageBase64`/`size` pair |
| `_temp_image_path` context manager | three NamedTemporaryFile + swallowed-unlink dances |
| `_row_from_memory` / `_row_text_values` | four zips of `CSV_HEADERS` against `_row_values_for_csv` |
| `MEMORY_FIELD_HEADERS` | three independently maintained copies of the same sixteen-field map |
| `_level_map_for_radio` / `_blank_radio_instance` | duplicated power-level fallback and `radio_cls(None)`-then-`""` constructor |
| `_issue` / `_setting_issue` / `_settings_validation_payload` | nine hand-built issue dicts, three seven-key settings replies, two duplicated message strings |
| Column metadata builders | 21 hand-written column dicts in four recurring shapes; `DV_ONLY_HEADERS` now drives the D-STAR columns too |
| `_read_radio_payload` | the five-step post-read tail shared by serial download and image load |
| `_read_memory` / `_erase_memory` | four inline `ExternalMemoryProperties` guards |

## Deliberately not done

- `upload_image_base64` is a public entry point with no caller anywhere. Left in place; delete it if you agree it is dead.
- The cached-image preamble shared by upload and export was left alone: the two callers differ in cache-miss policy and progress reporting.
- Latent inconsistency, unchanged here: the upload path reads existing memories through `get_memory_extra` but the preflight in `validate_rows_for_upload` does not, so the two can disagree about a row that only changes a comment on an `ExternalMemoryProperties` radio.

## Verification

`npm test`: 396 + 161 + 562 + 18 passing after every commit's compile and pyright check, and on the final tree. `npm run check:python` clean.

## Dependencies

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
