### PR TITLE
Replace the Actions menu with flat toolbar buttons

### DIFF
--- a/tests/channels/ui-repeater-modal.mjs
+++ b/tests/channels/ui-repeater-modal.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
 
 import { REPEATER_REQUEST_TIMEOUT_MS } from "../../web/js/request-timeout.js";
 import { createRepeaterQuery } from "../../web/js/ui/repeater-query.js";
 import { rowGeo } from "../../web/js/row-geo.js";
 import { FakeElement, installFakeDom } from "../support/fake-dom.mjs";
+import { repoRoot } from "../support/repo-paths.mjs";
 
 // The unified query modal is driven directly rather than through
 // createUiController, so each test can assert on exactly what it hands its
@@ -892,6 +895,31 @@ function installGatedRsgbFetch(bySquare) {
   return { calls, release: () => openGate() };
 }
 
+// installGatedRsgbFetch()'s general-purpose sibling: every request is held open
+// until the test releases it, whatever the URL, so a source can be caught with
+// its dictionary still loading.
+function installGatedFetch(routes) {
+  const calls = [];
+  let openGate;
+  const gate = new Promise((resolve) => {
+    openGate = resolve;
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (url, init) => {
+      const text = String(url);
+      calls.push({ url: text, init });
+      await gate;
+      const route = routes.find((entry) => text.includes(entry.match));
+      if (!route) {
+        throw new Error(`Unrouted fetch: ${text}`);
+      }
+      return { ok: true, status: 200, text: async () => route.body ?? "" };
+    },
+  });
+  return { calls, release: () => openGate() };
+}
+
 function repeaterRecord(overrides = {}) {
   return {
     id: 199,
@@ -914,6 +942,49 @@ const LONDON = { coords: { latitude: 51.5072, longitude: -0.1276 } };
 async function openRsgb(dom) {
   await dom.channelImportRsgbEl.dispatch("click");
 }
+
+// Every directory is one click from every other now that the toolbar carries
+// them all, so a dictionary that is still loading has to lose to the source
+// the user asked for next. Before the generation check, the late resolution
+// rebuilt the modal under the newer source's title.
+test("a directory still loading its options cannot replace the one opened after it", async () => {
+  const { query, dom, log } = buildHarness();
+  const { calls, release } = installGatedFetch([{ match: "/przemienniki/meta", body: META_JSON }]);
+
+  // przemienniki has to fetch its filter dictionary; RSGB's options are
+  // static, so the second click finishes while the first is still in flight.
+  const pending = dom.channelImportPrzemiennikiEl.dispatch("click");
+  await flush();
+  assert.deepEqual(calls.map((call) => call.url), ["https://proxy.example.com/przemienniki/meta"]);
+  await dom.channelImportRsgbEl.dispatch("click");
+  assert.equal(dom.repeaterQueryTitleEl.textContent, "Query RSGB ETCC API");
+
+  release();
+  await pending;
+  await flush();
+
+  assert.equal(query.isModalOpen(), true, "the modal the user asked for must stay open");
+  assert.equal(
+    dom.repeaterQueryTitleEl.textContent,
+    "Query RSGB ETCC API",
+    "the superseded load must not retitle the modal",
+  );
+  // The fields belong to RSGB too, not just the title: RSGB offers a locator,
+  // which no przemienniki form does.
+  assert.ok(grid(dom).querySelectorAll('input[name="locator"]').length > 0);
+  assert.equal(log.statuses.at(-1), "Configure RSGB ETCC query.");
+});
+
+// The button is hidden by web/js/ui/repeater-query.js when a blank proxy base
+// makes its source unavailable, which only works if the stylesheet lets it:
+// the toolbar's own display declaration outranks the browser's [hidden] rule,
+// so a visible button would sit there doing nothing when clicked.
+test("the toolbar lets an unavailable source's button stay hidden", () => {
+  const styles = fs.readFileSync(path.join(repoRoot, "web", "styles.css"), "utf8");
+  const rule = styles.match(/\.channel-toolbar button\[hidden\] \{([^}]*)\}/);
+  assert.ok(rule, "toolbar buttons need a rule restoring the [hidden] default");
+  assert.match(rule[1], /display:\s*none/);
+});
 
 test("the RSGB modal opens without a network round trip", async () => {
   const { query, dom, table } = buildHarness();

--- a/tests/channels/ui-repeater-modal.mjs
+++ b/tests/channels/ui-repeater-modal.mjs
@@ -222,7 +222,7 @@ function buildHarness({
   dom.repeaterQueryModalEl.classList.add("hidden");
 
   const log = { statuses: [], debug: [], errors: [] };
-  const table = { menuOpenCalls: [], inserted: [] };
+  const table = { inserted: [] };
 
   const ctx = {
     dom,
@@ -233,7 +233,6 @@ function buildHarness({
       reportActionError: (label, error) => log.errors.push(`${label}: ${error?.message || error}`),
     },
     table: {
-      setMenuOpen: (open) => table.menuOpenCalls.push(open),
       insertRowsAtSelectionOrEnd: (rows, label) => table.inserted.push({ rows, label }),
       rowBuilderHooks: () => ({
         createBlankRow: () => Object.fromEntries(headers.map((column) => [column, ""])),
@@ -916,7 +915,7 @@ async function openRsgb(dom) {
   await dom.channelImportRsgbEl.dispatch("click");
 }
 
-test("the RSGB modal opens without a network round trip and closes the actions menu", async () => {
+test("the RSGB modal opens without a network round trip", async () => {
   const { query, dom, table } = buildHarness();
   const calls = installRsgbFetch({});
   assert.equal(query.isModalOpen(), false);
@@ -924,7 +923,6 @@ test("the RSGB modal opens without a network round trip and closes the actions m
   await openRsgb(dom);
   assert.equal(query.isModalOpen(), true);
   assert.equal(dom.repeaterQueryTitleEl.textContent, "Query RSGB ETCC API");
-  assert.deepEqual(table.menuOpenCalls, [false], "the actions menu must close behind the modal");
   assert.deepEqual(calls, [], "the static filter options need no dictionary fetch");
   // The first focusable control is the first band checkbox — the fixed
   // country row offers nothing to focus.

--- a/tests/support/fake-dom.mjs
+++ b/tests/support/fake-dom.mjs
@@ -412,8 +412,6 @@ export const UI_STUBBED_SELECTORS = new Map([
   ["#app-progress-bar", "progress"],
   ["#channel-insert", "button"],
   ["#channel-remove", "button"],
-  ["#channel-menu-toggle", "button"],
-  ["#channel-menu-popup", "div"],
   ["#channel-add-gmrs", "button"],
   ["#channel-add-frs", "button"],
   ["#channel-add-pmr446", "button"],

--- a/web/index.html
+++ b/web/index.html
@@ -201,20 +201,54 @@
 
           <div id="channel-editor" class="editor-view is-active">
             <!--
-              Every channel action is its own toolbar button: the flag on an
-              import button says which country or region it covers, and the
+              Every channel action is its own toolbar button. The editing and
+              clipboard actions are inline SVG rather than emoji: emoji has no
+              glyph that reads as "copy", and a stroked icon inherits the
+              button's text colour, so it greys out with a disabled button
+              instead of staying full-colour. The import buttons keep an emoji
+              flag for the country or region they cover, and every button's
               title/aria-label spells that out for anyone who cannot read the
               flag (Windows renders regional-indicator pairs as letters).
             -->
             <div class="channel-toolbar">
-              <button id="channel-insert" type="button" class="channel-toolbar-icon" title="Insert new channel" aria-label="Insert new channel">➕</button>
-              <button id="channel-remove" type="button" class="channel-toolbar-icon" title="Remove selected channels" aria-label="Remove selected channels">➖</button>
-              <button id="channel-move-up" type="button" class="channel-toolbar-icon" title="Move selected channels up (Alt+ArrowUp)" aria-label="Move selected channels up">⬆️</button>
-              <button id="channel-move-down" type="button" class="channel-toolbar-icon" title="Move selected channels down (Alt+ArrowDown)" aria-label="Move selected channels down">⬇️</button>
+              <button id="channel-insert" type="button" class="channel-toolbar-icon" title="Insert new channel" aria-label="Insert new channel">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+              </button>
+              <button id="channel-remove" type="button" class="channel-toolbar-icon" title="Remove selected channels" aria-label="Remove selected channels">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14" /></svg>
+              </button>
+              <button id="channel-move-up" type="button" class="channel-toolbar-icon" title="Move selected channels up (Alt+ArrowUp)" aria-label="Move selected channels up">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 19V5M6 11l6-6 6 6" /></svg>
+              </button>
+              <button id="channel-move-down" type="button" class="channel-toolbar-icon" title="Move selected channels down (Alt+ArrowDown)" aria-label="Move selected channels down">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M6 13l6 6 6-6" /></svg>
+              </button>
               <span class="channel-toolbar-divider" role="separator" aria-orientation="vertical"></span>
-              <button id="channel-cut" type="button" class="channel-toolbar-icon" title="Cut the selected channels to the clipboard" aria-label="Cut selected channels">✂️</button>
-              <button id="channel-copy" type="button" class="channel-toolbar-icon" title="Copy the selected channels to the clipboard" aria-label="Copy selected channels">📋</button>
-              <button id="channel-paste" type="button" class="channel-toolbar-icon" title="Paste channels from the clipboard" aria-label="Paste channels">📥</button>
+              <button id="channel-cut" type="button" class="channel-toolbar-icon" title="Cut the selected channels to the clipboard" aria-label="Cut selected channels">
+                <!-- Scissors: two handles bottom-left, blades crossing to the upper right. -->
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <circle cx="6" cy="6" r="2.5" /><circle cx="6" cy="18" r="2.5" />
+                  <path d="M7.8 7.8 19.5 19.5M7.8 16.2 19.5 4.5" />
+                </svg>
+              </button>
+              <button id="channel-copy" type="button" class="channel-toolbar-icon" title="Copy the selected channels to the clipboard" aria-label="Copy selected channels">
+                <!-- Two stacked sheets. The back sheet is drawn as an open path
+                     rather than a second rect, so the front one does not have to
+                     be filled to hide the corner behind it - a fill would go
+                     opaque against the button's gradient. -->
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" />
+                  <rect x="8" y="8" width="13" height="13" rx="2" />
+                </svg>
+              </button>
+              <button id="channel-paste" type="button" class="channel-toolbar-icon" title="Paste channels from the clipboard" aria-label="Paste channels">
+                <!-- Clipboard with its clip: the board is an open path so the
+                     clip sits in the gap rather than on top of a drawn edge. -->
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M9 4.5H7a2 2 0 0 0-2 2V19a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6.5a2 2 0 0 0-2-2h-2" />
+                  <rect x="9" y="2.5" width="6" height="4" rx="1.25" />
+                </svg>
+              </button>
               <span class="channel-toolbar-divider" role="separator" aria-orientation="vertical"></span>
               <button
                 id="channel-add-gmrs"

--- a/web/index.html
+++ b/web/index.html
@@ -200,55 +200,81 @@
           </div>
 
           <div id="channel-editor" class="editor-view is-active">
+            <!--
+              Every channel action is its own toolbar button: the flag on an
+              import button says which country or region it covers, and the
+              title/aria-label spells that out for anyone who cannot read the
+              flag (Windows renders regional-indicator pairs as letters).
+            -->
             <div class="channel-toolbar">
-              <button id="channel-insert" type="button" title="Insert new channel" aria-label="Insert new channel">➕</button>
-              <button id="channel-remove" type="button" title="Remove selected channels" aria-label="Remove selected channels">➖</button>
-              <button id="channel-move-up" type="button" title="Move selected channels up (Alt+ArrowUp)" aria-label="Move selected channels up">⬆️</button>
-              <button id="channel-move-down" type="button" title="Move selected channels down (Alt+ArrowDown)" aria-label="Move selected channels down">⬇️</button>
-              <div class="channel-menu">
+              <button id="channel-insert" type="button" class="channel-toolbar-icon" title="Insert new channel" aria-label="Insert new channel">➕</button>
+              <button id="channel-remove" type="button" class="channel-toolbar-icon" title="Remove selected channels" aria-label="Remove selected channels">➖</button>
+              <button id="channel-move-up" type="button" class="channel-toolbar-icon" title="Move selected channels up (Alt+ArrowUp)" aria-label="Move selected channels up">⬆️</button>
+              <button id="channel-move-down" type="button" class="channel-toolbar-icon" title="Move selected channels down (Alt+ArrowDown)" aria-label="Move selected channels down">⬇️</button>
+              <span class="channel-toolbar-divider" role="separator" aria-orientation="vertical"></span>
+              <button id="channel-cut" type="button" class="channel-toolbar-icon" title="Cut the selected channels to the clipboard" aria-label="Cut selected channels">✂️</button>
+              <button id="channel-copy" type="button" class="channel-toolbar-icon" title="Copy the selected channels to the clipboard" aria-label="Copy selected channels">📋</button>
+              <button id="channel-paste" type="button" class="channel-toolbar-icon" title="Paste channels from the clipboard" aria-label="Paste channels">📥</button>
+              <span class="channel-toolbar-divider" role="separator" aria-orientation="vertical"></span>
+              <button
+                id="channel-add-gmrs"
+                type="button"
+                title="United States: add the 30 GMRS channels, 462/467 MHz, including the 8 repeater pairs"
+              >
+                <span aria-hidden="true">🇺🇸</span> GMRS
+              </button>
+              <button
+                id="channel-add-frs"
+                type="button"
+                title="United States: add the 22 licence-free FRS simplex channels, 462/467 MHz"
+              >
+                <span aria-hidden="true">🇺🇸</span> FRS
+              </button>
+              <button
+                id="channel-add-pmr446"
+                type="button"
+                title="Europe: add the 16 licence-free PMR446 simplex channels, 446 MHz"
+              >
+                <span aria-hidden="true">🇪🇺</span> PMR446
+              </button>
+              <span class="channel-toolbar-divider" role="separator" aria-orientation="vertical"></span>
+              <!--
+                A labelled group rather than four loose buttons, so the
+                "Repeaters" heading reaches assistive technology as the group
+                name instead of being a caption only sighted users get. Each
+                button keeps its own title, which is what becomes its
+                description.
+              -->
+              <div class="channel-toolbar-group" role="group" aria-labelledby="channel-repeater-label">
+                <span class="channel-toolbar-label" id="channel-repeater-label">Repeaters</span>
                 <button
-                  id="channel-menu-toggle"
+                  id="channel-import-przemienniki"
                   type="button"
-                  title="Channel actions"
-                  aria-label="Channel actions"
-                  aria-haspopup="true"
-                  aria-expanded="false"
+                  title="Poland and neighbouring Europe: query the przemienniki.net repeater directory"
                 >
-                  Actions
+                  <span aria-hidden="true">🇪🇺</span> przemienniki.net
                 </button>
-                <div id="channel-menu-popup" class="channel-menu-popup hidden" role="menu">
-                  <button id="channel-copy" type="button" role="menuitem">
-                    📋 Copy selected channels
-                  </button>
-                  <button id="channel-cut" type="button" role="menuitem">
-                    ✂️ Cut selected channels
-                  </button>
-                  <button id="channel-paste" type="button" role="menuitem">
-                    📥 Paste channels
-                  </button>
-                  <hr class="channel-menu-separator" />
-                  <button id="channel-add-gmrs" type="button" role="menuitem">
-                    🇺🇸 Add GMRS channels
-                  </button>
-                  <button id="channel-add-frs" type="button" role="menuitem">
-                    🇺🇸 Add FRS channels
-                  </button>
-                  <button id="channel-add-pmr446" type="button" role="menuitem">
-                    🇪🇺 Add PMR446 channels
-                  </button>
-                  <button id="channel-import-przemienniki" type="button" role="menuitem">
-                    🇪🇺 Query przemienniki.net
-                  </button>
-                  <button id="channel-import-repeaterbook" type="button" role="menuitem">
-                    🌍 Query repeaterbook.com
-                  </button>
-                  <button id="channel-import-irts" type="button" role="menuitem">
-                    🇮🇪 Query IRTS repeaters
-                  </button>
-                  <button id="channel-import-rsgb" type="button" role="menuitem">
-                    🇬🇧 Query RSGB ETCC API
-                  </button>
-                </div>
+                <button
+                  id="channel-import-repeaterbook"
+                  type="button"
+                  title="Worldwide: query the RepeaterBook directory"
+                >
+                  <span aria-hidden="true">🌍</span> repeaterbook.com
+                </button>
+                <button
+                  id="channel-import-irts"
+                  type="button"
+                  title="Ireland: query the IRTS repeater directory"
+                >
+                  <span aria-hidden="true">🇮🇪</span> IRTS
+                </button>
+                <button
+                  id="channel-import-rsgb"
+                  type="button"
+                  title="United Kingdom: query the RSGB ETCC repeater directory"
+                >
+                  <span aria-hidden="true">🇬🇧</span> RSGB
+                </button>
               </div>
             </div>
             <div class="channel-grid">
@@ -273,8 +299,8 @@
                     to read the channel list.
                   </li>
                   <li>
-                    You can also add nearby repeater channels by selecting a data source
-                    from the Actions menu.
+                    You can also add nearby repeater channels by picking a data source
+                    from the toolbar above the grid.
                   </li>
                   <li>
                     If you already have a codeplug either as CSV or in binary format,

--- a/web/js/ui.js
+++ b/web/js/ui.js
@@ -137,8 +137,7 @@ export function createUiController() {
     serial.bindEvents();
 
     // Escape closes the topmost open surface: the import prompt, then the
-    // channel extras editor, then the repeater modals, then the channel
-    // actions menu.
+    // channel extras editor, then the repeater modals.
     document.addEventListener("keydown", (event) => {
       if (event.key === "Escape") {
         if (codeplugIo.isImportChoiceModalOpen()) {
@@ -155,9 +154,7 @@ export function createUiController() {
         }
         if (repeaterQuery.isModalOpen()) {
           repeaterQuery.setModalOpen(false);
-          return;
         }
-        table.setMenuOpen(false);
         return;
       }
       if (event.altKey && (event.key === "ArrowUp" || event.key === "ArrowDown")) {

--- a/web/js/ui/channel-table.js
+++ b/web/js/ui/channel-table.js
@@ -1205,18 +1205,6 @@ export function createChannelTable({ dom, state, log, actions }) {
     return applied;
   }
 
-  function setMenuOpen(open) {
-    if (!dom.channelMenuToggleEl || !dom.channelMenuPopupEl) {
-      return;
-    }
-    dom.channelMenuPopupEl.classList.toggle("hidden", !open);
-    dom.channelMenuToggleEl.setAttribute("aria-expanded", open ? "true" : "false");
-  }
-
-  function toggleMenu() {
-    setMenuOpen(dom.channelMenuPopupEl.classList.contains("hidden"));
-  }
-
   // Resolve which channel and column an event inside the grid belongs to. The
   // row index is read from the element at event time, never captured when the
   // element was built, so recycled rows always report the channel they are
@@ -1311,52 +1299,28 @@ export function createChannelTable({ dom, state, log, actions }) {
     dom.channelMoveDownEl.addEventListener("click", () => {
       moveSelectedChannelRows(1);
     });
-    dom.channelMenuToggleEl.addEventListener("click", (event) => {
-      event.stopPropagation();
-      toggleMenu();
-    });
     dom.channelCopyEl.addEventListener("click", async () => {
-      setMenuOpen(false);
       await writeChannelTsvToClipboard("copy", false);
     });
     dom.channelCutEl.addEventListener("click", async () => {
-      setMenuOpen(false);
       await writeChannelTsvToClipboard("cut", true);
     });
     dom.channelPasteEl.addEventListener("click", async () => {
-      setMenuOpen(false);
       await pasteChannelsViaApi();
     });
     dom.channelAddGmrsEl.addEventListener("click", () => {
-      setMenuOpen(false);
       addBandPlanChannels(buildGmrsRows, "GMRS");
     });
     dom.channelAddFrsEl.addEventListener("click", () => {
-      setMenuOpen(false);
       addBandPlanChannels(buildFrsRows, "FRS");
     });
     dom.channelAddPmr446El.addEventListener("click", () => {
-      setMenuOpen(false);
       addBandPlanChannels(buildPmr446Rows, "PMR446");
-    });
-
-    document.addEventListener("click", (event) => {
-      if (!dom.channelMenuPopupEl || dom.channelMenuPopupEl.classList.contains("hidden")) {
-        return;
-      }
-      const target = event.target;
-      if (!(target instanceof Node)) {
-        return;
-      }
-      if (dom.channelMenuPopupEl.contains(target) || dom.channelMenuToggleEl.contains(target)) {
-        return;
-      }
-      setMenuOpen(false);
     });
 
     // Ctrl/Cmd+C, X, V arrive as native clipboard events, which supply
     // clipboardData synchronously and need no permission prompt (unlike the
-    // async navigator.clipboard API used by the menu items). The guard defers
+    // async navigator.clipboard API used by the toolbar buttons). The guard defers
     // to normal browser behavior inside inputs/selects and text selections.
     document.addEventListener("copy", (event) => {
       if (!channelShortcutsActive(event, { respectTextSelection: true })) {
@@ -1400,7 +1364,6 @@ export function createChannelTable({ dom, state, log, actions }) {
     rowBuilderHooks,
     channelShortcutsActive,
     moveSelectedChannelRows,
-    setMenuOpen,
     refreshVisibleRows: renderRowWindow,
   };
 }

--- a/web/js/ui/dom.js
+++ b/web/js/ui/dom.js
@@ -66,8 +66,6 @@ export const REQUIRED_ELEMENTS = {
   channelCopyEl: "#channel-copy",
   channelCutEl: "#channel-cut",
   channelPasteEl: "#channel-paste",
-  channelMenuToggleEl: "#channel-menu-toggle",
-  channelMenuPopupEl: "#channel-menu-popup",
   channelAddGmrsEl: "#channel-add-gmrs",
   channelAddFrsEl: "#channel-add-frs",
   channelAddPmr446El: "#channel-add-pmr446",

--- a/web/js/ui/repeater-query.js
+++ b/web/js/ui/repeater-query.js
@@ -59,7 +59,7 @@ export function createRepeaterQuery(ctx) {
   const sources = createRepeaterSources(ctx, { endpoints });
   for (const source of sources) {
     if (!source.available) {
-      dom[source.menuButton].hidden = true;
+      dom[source.toolbarButton].hidden = true;
     }
   }
 
@@ -168,7 +168,6 @@ export function createRepeaterQuery(ctx) {
     if (!source || !source.available) {
       return;
     }
-    ctx.table.setMenuOpen(false);
     let loadedOptions = null;
     if (source.loadOptions) {
       log.setStatus(`Loading ${source.label} query options...`);
@@ -225,7 +224,7 @@ export function createRepeaterQuery(ctx) {
 
   function bindEvents() {
     for (const source of sources) {
-      dom[source.menuButton].addEventListener("click", async () => {
+      dom[source.toolbarButton].addEventListener("click", async () => {
         try {
           await openModal(source.key);
         } catch (error) {

--- a/web/js/ui/repeater-query.js
+++ b/web/js/ui/repeater-query.js
@@ -64,6 +64,12 @@ export function createRepeaterQuery(ctx) {
   }
 
   let activeSource = sources[0];
+  // Counts openModal() calls so a superseded one can bow out. Sources that
+  // fetch a dictionary resolve after sources whose options are static, and the
+  // directory buttons are now one click apart on the toolbar rather than two
+  // clicks apart through a menu — so the slow first click would otherwise
+  // rebuild the modal the second click had already opened.
+  let openGeneration = 0;
   let fieldInstances = [];
   let positionField = null;
   const positionState = { latitudeText: "", longitudeText: "" };
@@ -168,10 +174,17 @@ export function createRepeaterQuery(ctx) {
     if (!source || !source.available) {
       return;
     }
+    const generation = ++openGeneration;
     let loadedOptions = null;
     if (source.loadOptions) {
       log.setStatus(`Loading ${source.label} query options...`);
       loadedOptions = await source.loadOptions();
+      // Another source was asked for while this one was loading; it owns the
+      // modal now, so leave it alone. The load still resolved, so a failure
+      // here is still reported by the caller.
+      if (generation !== openGeneration) {
+        return;
+      }
     }
     activeSource = source;
     buildFields(source, loadedOptions);

--- a/web/js/ui/repeater-sources.js
+++ b/web/js/ui/repeater-sources.js
@@ -113,7 +113,7 @@ export function createRepeaterSources(ctx, { endpoints }) {
     label,
     actionLabel,
     insertLabel,
-    menuButton,
+    toolbarButton,
     sourceEndpoints,
   }) {
     const apiUrl = sourceEndpoints?.apiUrl || "";
@@ -126,7 +126,7 @@ export function createRepeaterSources(ctx, { endpoints }) {
 
     return {
       key,
-      menuButton,
+      toolbarButton,
       // Proxy-dependent sources have null endpoints when the configured base
       // is blank. IRTS always receives its default api.codeplug.org endpoints.
       available: Boolean(apiUrl && metaUrl),
@@ -150,7 +150,7 @@ export function createRepeaterSources(ctx, { endpoints }) {
           optionsPromise = (async () => {
             // The whole exchange runs under one deadline, body read included:
             // this fetch is what the modal blocks on while it opens, so a
-            // stalled proxy would otherwise leave the menu click doing nothing
+            // stalled proxy would otherwise leave the toolbar click doing nothing
             // visible for minutes.
             const text = await withRequestTimeout(`${label} dictionary request`, async (signal) => {
               const response = await fetch(metaUrl, { signal });
@@ -266,7 +266,7 @@ export function createRepeaterSources(ctx, { endpoints }) {
     const actionLabel = "RSGB ETCC";
     return {
       key: "rsgb",
-      menuButton: "channelImportRsgbEl",
+      toolbarButton: "channelImportRsgbEl",
       available: true,
       title: "Query RSGB ETCC API",
       label: "RSGB ETCC",
@@ -401,7 +401,7 @@ export function createRepeaterSources(ctx, { endpoints }) {
       label: "przemienniki.net",
       actionLabel: "Przemienniki",
       insertLabel: "przemienniki",
-      menuButton: "channelImportPrzemiennikiEl",
+      toolbarButton: "channelImportPrzemiennikiEl",
       sourceEndpoints: endpoints?.przemienniki,
     }),
     remoteDirectorySource({
@@ -409,7 +409,7 @@ export function createRepeaterSources(ctx, { endpoints }) {
       label: "repeaterbook.com",
       actionLabel: "RepeaterBook",
       insertLabel: "repeaterbook",
-      menuButton: "channelImportRepeaterbookEl",
+      toolbarButton: "channelImportRepeaterbookEl",
       sourceEndpoints: endpoints?.repeaterbook,
     }),
     remoteDirectorySource({
@@ -417,7 +417,7 @@ export function createRepeaterSources(ctx, { endpoints }) {
       label: "IRTS",
       actionLabel: "IRTS",
       insertLabel: "IRTS",
-      menuButton: "channelImportIrtsEl",
+      toolbarButton: "channelImportIrtsEl",
       sourceEndpoints: endpoints?.irts,
     }),
     rsgbSource(),

--- a/web/styles.css
+++ b/web/styles.css
@@ -842,6 +842,14 @@ button:disabled {
   white-space: nowrap;
 }
 
+/* The display above is author-level, so it outranks the browser's own
+   [hidden] rule. A repeater source that a blank proxy base makes unavailable
+   is hidden exactly that way (web/js/ui/repeater-query.js), and without this
+   its button would stay on the toolbar doing nothing when clicked. */
+.channel-toolbar button[hidden] {
+  display: none;
+}
+
 /* Icon-only buttons are squares matching the toolbar height. */
 .channel-toolbar button.channel-toolbar-icon {
   width: 2.3rem;

--- a/web/styles.css
+++ b/web/styles.css
@@ -842,11 +842,23 @@ button:disabled {
   white-space: nowrap;
 }
 
-/* Emoji-only buttons are squares matching the toolbar height. */
+/* Icon-only buttons are squares matching the toolbar height. */
 .channel-toolbar button.channel-toolbar-icon {
   width: 2.3rem;
   padding: 0;
-  font-size: 1rem;
+}
+
+/* One stroke style for the whole icon set. currentColor is the point: the
+   icons follow the button's text colour, so they grey out with a disabled
+   button and stay legible in the dark theme, neither of which emoji did. */
+.channel-toolbar-icon svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.75;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* Names the group of buttons that follows it; not a control itself. */

--- a/web/styles.css
+++ b/web/styles.css
@@ -809,30 +809,58 @@ button:disabled {
   display: flex;
 }
 
+/* The toolbar wraps: it carries every channel action now, and on a narrow
+   window the row is wider than the editor pane. */
 .channel-toolbar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.45rem;
   margin-bottom: 0.6rem;
   flex: 0 0 auto;
   position: relative;
 }
 
-/* Uniform height for all toolbar buttons (+, -, up, down, Actions). */
-.channel-toolbar > button,
-#channel-menu-toggle {
+/* The repeater sources travel together so their group label stays with them
+   when the toolbar wraps. */
+.channel-toolbar-group {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+/* Uniform height for every toolbar button, icon-only or labelled. */
+.channel-toolbar button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.3rem;
   height: 2.3rem;
-  padding: 0.3rem 0.5rem;
+  padding: 0.3rem 0.6rem;
   line-height: 1;
+  white-space: nowrap;
 }
 
-/* The icon buttons are squares matching the toolbar height. */
-.channel-toolbar > button {
+/* Emoji-only buttons are squares matching the toolbar height. */
+.channel-toolbar button.channel-toolbar-icon {
   width: 2.3rem;
   padding: 0;
+  font-size: 1rem;
+}
+
+/* Names the group of buttons that follows it; not a control itself. */
+.channel-toolbar-label {
+  color: var(--muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+/* Separates the toolbar's action groups. */
+.channel-toolbar-divider {
+  width: 1px;
+  height: 1.5rem;
+  background: var(--border);
 }
 
 /* Holds the grid and the empty-state notice, only one of which is ever shown. */
@@ -1062,46 +1090,6 @@ button:disabled {
   color: var(--warn-text-2);
   font-size: 0.78rem;
   line-height: 1.3;
-}
-
-#channel-insert,
-#channel-remove {
-  min-width: 2.1rem;
-  padding: 0.3rem 0.45rem;
-  font-size: 1rem;
-  line-height: 1;
-}
-
-.channel-menu {
-  position: relative;
-}
-
-.channel-menu-popup {
-  position: absolute;
-  top: calc(100% + 0.25rem);
-  left: 0;
-  z-index: 20;
-  min-width: 24rem;
-  padding: 0.25rem;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--surface);
-  box-shadow: 0 6px 16px var(--shadow-color);
-}
-
-.channel-menu-popup.hidden {
-  display: none;
-}
-
-.channel-menu-popup button {
-  width: 100%;
-  text-align: left;
-}
-
-.channel-menu-popup .channel-menu-separator {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin: 0.25rem 0.2rem;
 }
 
 /* Drag-and-drop file loading (web/js/ui/codeplug-io.js). The whole page is the
@@ -2002,24 +1990,16 @@ button:disabled {
   .left-panel button,
   .left-panel select,
   .serial-actions button,
-  .channel-toolbar > button,
-  #channel-menu-toggle,
-  .channel-menu-popup button,
+  .channel-toolbar button,
   .modal-actions button,
   .debug-header-actions button {
     min-height: 2.75rem;
   }
 
-  /* Keep the icon buttons square at the larger touch-target height. */
-  .channel-toolbar > button {
+  /* Keep the emoji-only buttons square at the larger touch-target height. */
+  .channel-toolbar button.channel-toolbar-icon {
     min-width: 2.75rem;
-  }
-
-  /* The actions popup is fixed-width on desktop; keep it on-screen on phones. */
-  .channel-menu-popup {
-    min-width: 0;
-    width: max-content;
-    max-width: calc(100vw - 2rem);
+    width: 2.75rem;
   }
 
   #debug-output {


### PR DESCRIPTION
## What changed

The channel toolbar's **Actions** dropdown is gone. Every action it held is now its own button, in one wrapping row:

```
[+] [−] [↑] [↓] │ [✂] [⧉] [📋] │ 🇺🇸 GMRS  🇺🇸 FRS  🇪🇺 PMR446 │ Repeaters  🇪🇺 przemienniki.net  🌍 repeaterbook.com  🇮🇪 IRTS  🇬🇧 RSGB
```

- **Clipboard actions** (cut / copy / paste) are icon-only.
- **Band plans** (GMRS, FRS, PMR446) and the four **repeater directories** carry the flag of the country or region they cover, since a flag alone does not say what an import contains.
- Every button has a `title` spelling that out — e.g. *"United Kingdom: query the RSGB ETCC repeater directory"*, *"Europe: add the 16 licence-free PMR446 simplex channels, 446 MHz"*.
- The four repeater buttons sit in a `role="group"` labelled **Repeaters**, so the heading reaches assistive technology as the group name rather than being a caption only sighted users get.

All seven icon buttons are inline SVG rather than emoji. Emoji has no glyph that reads as *copy* — 📋 and 📥 both stand for containers, not actions — so the clipboard trio uses the conventional line art, and the four editing buttons moved with them rather than leave the toolbar mixing coloured emoji with monochrome strokes.

## Why

Two clicks and a scan of a nine-item popup to reach an action that fits on the toolbar. The dropdown also hid *which* directories exist, which is most of what a new user needs to know.

Stroking the icons with `currentColor` fixes a second thing: an icon now follows its button's text colour, so it greys out when the button is disabled and stays legible in the dark theme. Emoji did neither — a disabled ➖ stayed full-colour while its label greyed out, reading as a live button.

## Notes for review

- **Deleted machinery:** the menu toggle, popup, outside-click close, and the Escape branch that shut it, plus `setMenuOpen` — which was on `channel-table.js`'s public surface and called by two siblings through `ctx.table` (`repeater-query.js` closed the menu behind its modal; `ui.js` gave Escape a fallback).
- **Import wiring is untouched.** `repeater-query.js` binds through `dom[source.toolbarButton]`, a config string, so keeping the `#channel-import-*` ids carried the whole thing across the rewrite. The field was renamed `menuButton` → `toolbarButton`, which is now accurate.
- **`aria-describedby` was deliberately avoided** on the repeater buttons: pointing them at the group label would have suppressed each `title` as the accessible description, losing exactly the detail the tooltips exist to carry. The `role="group"` wrapper gives the heading to screen readers *and* leaves the titles intact.
- **Band-plan tooltips name channel counts** (30 GMRS, 22 FRS, 16 PMR446) read off `web/js/datasources.js`. Nothing pins them, so editing those tables would leave the tooltips stale.
- **On a phone the toolbar becomes four rows** (~198px tall, no horizontal overflow at 375px). That's the honest cost of a flat toolbar over a dropdown.
- **Screenshots not regenerated.** `images/screenshot.png` and the social-preview images still show the old menu; per `CLAUDE.md` those are refreshed on `master`, not on a branch.

## New dependencies

None.

## Testing

- Full suite green: `npm test` — 550 / 161 / 562 / 23, zero failures.
- `tests/channels/ui-repeater-modal.mjs` lost its assertion that the RSGB modal closed the actions menu, and `tests/support/fake-dom.mjs` lost the two stubs for the removed elements.
- Verified in the browser: GMRS inserts its 30 rows, Insert adds rows through the new SVG-bearing button, the RSGB modal opens from its button and still closes on Escape, and the icons render correctly at 4× in both light and dark themes with disabled buttons dimming as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)